### PR TITLE
Fix malformed HTML in index template

### DIFF
--- a/server/views/index.tpl.html
+++ b/server/views/index.tpl.html
@@ -1,9 +1,7 @@
 <!DOCTYPE html>
 <html itemscope="" itemtype="http://schema.org/WebPage" lang="en">
-<meta http-equiv="content-type" content="text/html;charset=utf-8">
-
 <head>
-    <meta charset="utf-8">
+    <meta http-equiv="content-type" content="text/html;charset=utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta id="viewport" name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Michael D'Angelo</title>


### PR DESCRIPTION
Looks like malformed HTML (meta tag outside of head) is causing some combination of dependency versions to crash

Addresses #206