### PR TITLE
Simplifies React Helmet Integration

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,6 +13,7 @@ This site has been a work in progress since 2014. I have tried to make updates t
 - Make code splitting better - some bundles are under 1KB.
 - Make styles more modular.
 - Make FA integration less terrible (consider building FA library).
+- Simplify Favicon. See: https://news.ycombinator.com/item?id=25520655
 - Better tests
   - one test per component.
   - test using puppeteer again.

--- a/public/index.html
+++ b/public/index.html
@@ -4,8 +4,6 @@
     <meta http-equiv="content-type" content="text/html;charset=utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta id="viewport" name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Michael D'Angelo</title>
-    <meta name="description" content="Michael D'Angelo's personal website. Facts, thoughts, bad ideas, and everything else." data-react-helmet="true">
     <link rel="apple-touch-icon" sizes="57x57" href="%PUBLIC_URL%/images/favicon/apple-icon-57x57.png">
     <link rel="apple-touch-icon" sizes="60x60" href="%PUBLIC_URL%/images/favicon/apple-icon-60x60.png">
     <link rel="apple-touch-icon" sizes="72x72" href="%PUBLIC_URL%/images/favicon/apple-icon-72x72.png">

--- a/src/layouts/Main.js
+++ b/src/layouts/Main.js
@@ -11,7 +11,10 @@ const Main = (props) => (
   <>
     <Analytics />
     <ScrollToTop />
-    <Helmet titleTemplate="%s | Michael D'Angelo" defaultTitle="Michael D'Angelo" />
+    <Helmet titleTemplate="%s | Michael D'Angelo" defaultTitle="Michael D'Angelo">
+      {props.title && <title>{props.title}</title>}
+      <meta name="description" content={props.description} />
+    </Helmet>
     <div id="wrapper">
       <Header />
       <div id="main">
@@ -28,11 +31,15 @@ Main.propTypes = {
     PropTypes.node,
   ]),
   fullPage: PropTypes.bool,
+  title: PropTypes.string,
+  description: PropTypes.string,
 };
 
 Main.defaultProps = {
   children: null,
   fullPage: false,
+  title: null,
+  description: "Michael D'Angelo's personal website.",
 };
 
 export default Main;

--- a/src/pages/About.js
+++ b/src/pages/About.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Helmet } from 'react-helmet';
 import ReactMarkdown from 'react-markdown';
 import raw from 'raw.macro';
 
@@ -17,10 +16,10 @@ const count = markdown.split(/\s+/)
 const LinkRenderer = ({ ...children }) => <Link {...children} />;
 
 const About = () => (
-  <Main>
-    <Helmet title="About">
-      <meta name="description" content="Learn about Michael D'Angelo" />
-    </Helmet>
+  <Main
+    title="About"
+    description="Learn about Michael D'Angelo"
+  >
     <article className="post markdown" id="about">
       <header>
         <div className="title">

--- a/src/pages/Contact.js
+++ b/src/pages/Contact.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Helmet } from 'react-helmet';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import Main from '../layouts/Main';
@@ -8,10 +7,10 @@ import EmailLink from '../components/Contact/EmailLink';
 import data from '../data/contact';
 
 const Contact = () => (
-  <Main>
-    <Helmet title="Contact">
-      <meta name="description" content="Contact Michael D'Angelo via email @ michael.l.dangelo@gmail.com" />
-    </Helmet>
+  <Main
+    title="Contact"
+    description="Contact Michael D'Angelo via email @ michael.l.dangelo@gmail.com"
+  >
     <article className="post" id="contact">
       <header>
         <div className="title">

--- a/src/pages/Index.js
+++ b/src/pages/Index.js
@@ -1,14 +1,13 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Helmet } from 'react-helmet';
 
 import Main from '../layouts/Main';
 
 const Index = () => (
-  <Main>
-    <Helmet>
-      <meta name="description" content="Michael D'Angelo's personal website. New York based Stanford ICME graduate, co-founder and CTO of Arthena, and YC Alumni." />
-    </Helmet>
+  <Main
+    description={"Michael D'Angelo's personal website. New York based Stanford ICME graduate, "
+    + 'co-founder and CTO of Arthena, and YC Alumni.'}
+  >
     <article className="post" id="index">
       <header>
         <div className="title">

--- a/src/pages/Projects.js
+++ b/src/pages/Projects.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Helmet } from 'react-helmet';
 
 import Main from '../layouts/Main';
 
@@ -8,10 +7,10 @@ import Cell from '../components/Projects/Cell';
 import data from '../data/projects';
 
 const Projects = () => (
-  <Main>
-    <Helmet title="Projects">
-      <meta name="description" content="Learn about Michael D'Angelo's projects." />
-    </Helmet>
+  <Main
+    title="Projects"
+    description="Learn about Michael D'Angelo's projects."
+  >
     <article className="post" id="projects">
       <header>
         <div className="title">

--- a/src/pages/Resume.js
+++ b/src/pages/Resume.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Helmet } from 'react-helmet';
 
 import Main from '../layouts/Main';
 
@@ -24,10 +23,10 @@ const sections = [
 ];
 
 const Resume = () => (
-  <Main>
-    <Helmet title="Resume">
-      <meta name="description" content="Michael D'Angelo's Resume. Arthena, Matroid, YC, Skeptical Investments, Stanford ICME, Planet Labs, Facebook" />
-    </Helmet>
+  <Main
+    title="Resume"
+    description="Michael D'Angelo's Resume. Arthena, Matroid, YC, Skeptical Investments, Stanford ICME, Planet Labs, and Facebook."
+  >
     <article className="post" id="resume">
       <header>
         <div className="title">

--- a/src/pages/Stats.js
+++ b/src/pages/Stats.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Helmet } from 'react-helmet';
 
 import Main from '../layouts/Main';
 
@@ -8,10 +7,10 @@ import Personal from '../components/Stats/Personal';
 import Site from '../components/Stats/Site';
 
 const Stats = () => (
-  <Main>
-    <Helmet title="Stats">
-      <meta name="description" content="Some statistics about Michael D'Abngelo and mldangelo.com" />
-    </Helmet>
+  <Main
+    title="Stats"
+    description="Some statistics about Michael D'Angelo and mldangelo.com"
+  >
     <article className="post" id="stats">
       <header>
         <div className="title">


### PR DESCRIPTION
This PR sets react-helmet attributes in the template, rather than relying on a future render of react-helmet to overwrite pre-set attributes. It also removes the hard-coded description and title in `public/index.html` which should make adapting this project slightly easier. 

There are no visual or semantic changes to the website. The total bundle size is reduced by ~ 1 KB. 