### PR TITLE
Alternate email links non-stop

### DIFF
--- a/src/components/Contact/EmailLink.js
+++ b/src/components/Contact/EmailLink.js
@@ -45,7 +45,7 @@ const useInterval = (callback, delay) => {
   }, [delay]);
 };
 
-const EmailLink = (props) => {
+const EmailLink = ({ loopMessage }) => {
   const hold = 50; // ticks to wait after message is complete before rendering next message
   const delay = 50; // tick length in mS
 
@@ -62,7 +62,7 @@ const EmailLink = (props) => {
       newChar = 0;
     }
     if (newIdx === messages.length) {
-      if (props.loopMessage) {
+      if (loopMessage) {
         updateIter(0);
         updateChar(0);
       } else {
@@ -91,8 +91,9 @@ const EmailLink = (props) => {
 };
 
 EmailLink.defaultProps = {
-  loopMessage: Boolean,
+  loopMessage: false,
 };
+
 EmailLink.propTypes = {
   loopMessage: Boolean,
 };

--- a/src/components/Contact/EmailLink.js
+++ b/src/components/Contact/EmailLink.js
@@ -45,7 +45,7 @@ const useInterval = (callback, delay) => {
   }, [delay]);
 };
 
-const EmailLink = () => {
+const EmailLink = (props) => {
   const hold = 50; // ticks to wait after message is complete before rendering next message
   const delay = 50; // tick length in mS
 
@@ -62,8 +62,12 @@ const EmailLink = () => {
       newChar = 0;
     }
     if (newIdx === messages.length) {
-      updateIter(0);
-      updateChar(0);
+      if (props.loopMessage) {
+        updateIter(0);
+        updateChar(0);
+      } else {
+        setIsActive(false);
+      }
     } else {
       updateMessage(messages[newIdx].slice(0, newChar));
       updateIter(newIdx);
@@ -84,6 +88,13 @@ const EmailLink = () => {
       </a>
     </div>
   );
+};
+
+EmailLink.defaultProps = {
+  loopMessage: Boolean,
+};
+EmailLink.propTypes = {
+  loopMessage: Boolean,
 };
 
 export default EmailLink;

--- a/src/components/Contact/EmailLink.js
+++ b/src/components/Contact/EmailLink.js
@@ -51,7 +51,7 @@ const EmailLink = () => {
 
   const [idx, updateIter] = useState(0); // points to current message
   const [message, updateMessage] = useState(messages[idx]);
-  const [char, updateChar] = useState(messages[idx].length); // points to current char
+  const [char, updateChar] = useState(0); // points to current char
   const [isActive, setIsActive] = useState(true); // disable when all messages are printed
 
   useInterval(() => {
@@ -62,7 +62,8 @@ const EmailLink = () => {
       newChar = 0;
     }
     if (newIdx === messages.length) {
-      setIsActive(false);
+      updateIter(0);
+      updateChar(0);
     } else {
       updateMessage(messages[newIdx].slice(0, newChar));
       updateIter(newIdx);

--- a/src/pages/Contact.js
+++ b/src/pages/Contact.js
@@ -18,7 +18,7 @@ const Contact = () => (
       </header>
       <div className="email-at">
         <p>Feel free to get in touch. You can email me at: </p>
-        <EmailLink loopMessage />
+        <EmailLink />
       </div>
       <ContactIcons />
     </article>

--- a/src/pages/Contact.js
+++ b/src/pages/Contact.js
@@ -18,7 +18,7 @@ const Contact = () => (
       </header>
       <div className="email-at">
         <p>Feel free to get in touch. You can email me at: </p>
-        <EmailLink />
+        <EmailLink loopMessage />
       </div>
       <ContactIcons />
     </article>


### PR DESCRIPTION
Before the change, the email links stop alternating at 'thanks@mldangelo.com'. 
The new change allows the email link to keep updating non-stop. So after 'thanks@mldangelo.com', it rotates back to  'hi@mldangelo.com' and repeat. 