### PR TITLE
Update ReactMarkdown param to children

### DIFF
--- a/src/pages/About.js
+++ b/src/pages/About.js
@@ -28,7 +28,7 @@ const About = () => (
         </div>
       </header>
       <ReactMarkdown
-        source={markdown}
+        children={markdown}
         renderers={{
           Link: LinkRenderer,
         }}


### PR DESCRIPTION
Don't know if this is necessary but when I was using your template to build my personal website, I could not get the markdown to render with source={markdown}
They might've updated the param? https://www.npmjs.com/package/react-markdown

I'm pretty new to react so if this is not the case feel free to decline, thanks