### PR TITLE
fix(homepage): clip hero background to prevent mobile overflow

### DIFF
--- a/app/styles/pages/home.css
+++ b/app/styles/pages/home.css
@@ -166,8 +166,8 @@
   top: 35%;
   left: 50%;
   transform: translate(-50%, -50%);
-  width: 1200px;
-  height: 800px;
+  width: 60%;
+  height: 75%;
   background: radial-gradient(
     ellipse 100% 100% at 50% 50%,
     var(--color-accent-light) 0%,

--- a/app/styles/pages/home.css
+++ b/app/styles/pages/home.css
@@ -158,6 +158,8 @@
 .hero-bg {
   position: absolute;
   inset: 0;
+  overflow: hidden;
+  overflow: clip;
   pointer-events: none;
 }
 
@@ -166,8 +168,8 @@
   top: 35%;
   left: 50%;
   transform: translate(-50%, -50%);
-  width: 60%;
-  height: 75%;
+  width: 1200px;
+  height: 800px;
   background: radial-gradient(
     ellipse 100% 100% at 50% 50%,
     var(--color-accent-light) 0%,


### PR DESCRIPTION
Thanks for catching the mobile overflow issue.

We updated the implementation on this branch after reviewing it locally in browser screenshots.

## Summary
- preserve the original `1200px x 800px` hero glow on desktop
- clip the decorative hero background inside `.hero-bg`
- remove horizontal scrolling on mobile without shrinking the desktop effect

## Validation
- verified at `390px` wide: overflow drops from `405px` on `main` to `0` on this branch
- confirmed the desktop hero styling stays aligned with `main`
- `npm run build` passes

## Screenshots
Captured locally against `main` and this updated PR branch.

### Mobile (`390px` wide)
| Before (`main`) | After (updated PR) |
| --- | --- |
| ![Before mobile overflow](https://d.uguu.se/qxUnCQYi.png) | ![After mobile fixed](https://h.uguu.se/xeeZKNoM.png) |

### Desktop (`1440px` wide)
| Before (`main`) | After (updated PR) |
| --- | --- |
| ![Before desktop baseline](https://d.uguu.se/ZVTfRCiN.png) | ![After desktop preserved](https://o.uguu.se/NSCgHPKe.png) |