### PR TITLE
fix(home): prevent hero gradient from overflowing the viewport

### DIFF
--- a/app/styles/pages/home.css
+++ b/app/styles/pages/home.css
@@ -166,7 +166,7 @@
   top: 35%;
   left: 50%;
   transform: translate(-50%, -50%);
-  width: 1200px;
+  width: min(1200px, 100vw);
   height: 800px;
   background: radial-gradient(
     ellipse 100% 100% at 50% 50%,


### PR DESCRIPTION
## Summary

The decorative `.hero-gradient` on the homepage is hardcoded at `width: 1200px`. On any viewport narrower than 1200px (which is most laptops, all tablets, all phones), the absolutely-positioned element extends past the viewport edge and grows the document horizontally. The fixed `.site-header` then stretches with the document, pushing the burger menu off-screen on mobile.

This only affects `/` because `.hero-gradient` only exists in `Hero.tsx`.

## Repro

1. Open `/` in a browser
2. Resize the window to <1200px wide (or open on any phone/tablet)
3. Notice horizontal scroll bar at the bottom of the page
4. On a narrow mobile viewport, the burger menu in the header is positioned off-screen to the right — only visible after scrolling horizontally

<img width="1725" height="1078" alt="SCR-20260501-nxvh" src="https://github.com/user-attachments/assets/497125b1-724c-43ab-841d-996e62ea83b5" />


## Fix

```diff
- width: 1200px;
+ width: min(1200px, 100vw);
```

- ≥1200px viewport: identical to the original — 1200px focused glow
- <1200px viewport: caps at viewport width, so no horizontal overflow

Used `100vw` rather than `100%` because the parent `.page-main` has `max-width: 800px`, which would shrink the gradient too much (`100%` would resolve to 800px and shrink the glow on every screen size).

## Test plan

- [x] `npm run type-check` clean
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npm test` — 309/309 passing
- [x] `npm run build` clean
- [x] Verify homepage looks identical at ≥1200px viewport
- [x] Verify no horizontal scroll on narrow window (<1200px)
- [x] Verify burger menu visible at right edge of header on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)