### PR TITLE
chore(deps): bump the artifact and Pages actions in lockstep

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -106,7 +106,7 @@ jobs:
 
       - name: Upload coverage reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage
           path: coverage/
@@ -184,7 +184,7 @@ jobs:
           matrix.os == 'ubuntu-latest' &&
           matrix.node-version == '22.x' &&
           github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-output
           path: out/
@@ -230,16 +230,16 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Download validated build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-output
           path: out
 
       - name: Package GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: out
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Supersedes #915 and #917, which each bump only one side of a coupled pair.

`upload-artifact` → `download-artifact` and `upload-pages-artifact` → `deploy-pages` are matched pairs on the path that publishes the site. Dependabot opened PRs for `download-artifact` (v4→v8) and `upload-pages-artifact` (v3→v5) but none for their partners, so merging either alone leaves a mismatch across a major boundary that has had breaking artifact-API rewrites.

This moves all four together:

| action | from | to |
| --- | --- | --- |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `actions/upload-pages-artifact` | v3 | v5 |
| `actions/deploy-pages` | v4 | v5 |

The deploy path can only be exercised on `main`, so the post-merge run is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)