### PR TITLE
docs: correct and simplify fork guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,6 @@ npm run build        # Production build + static export
 **File-scoped (faster feedback):**
 
 ```bash
-npx tsc --noEmit path/to/file.tsx           # Type check single file
 npx biome check path/to/file.tsx            # Lint single file
 npm test -- ComponentName                    # Test single component
 ```
@@ -92,7 +91,7 @@ Next.js 16 (App Router) · React 19 · TypeScript · Tailwind CSS v4 · Biome ·
 - **Long-form markdown pages**: Prefer a dedicated renderer component that can parse markdown into semantic sections instead of styling raw headings globally; if `markdown-to-jsx` causes dev/runtime issues in App Router, a `'use client'` boundary may still be required even without hooks. Preserve stable heading ids when converting markdown headings so deep links and `scroll-margin-top` behavior keep working, prefer a shared helper over duplicating slug logic in each page component, and expose those anchors in the UI with section nav or self-links if readers are expected to use them
 - **Blog posts**: Markdown files in `content/writing/` with frontmatter (title, date, description); slug derived from filename
 - **Writing page**: Add external links in `src/data/writing.ts` and keep dated entries sorted newest first; local posts still live in `content/writing/`
-- **Design system ("Ground Station")**: Three type roles, and every element should pick one deliberately — `--font-display` (Bricolage Grotesque) for names and headings, `--font-body` (Newsreader) for prose, `--font-mono` (JetBrains Mono) for data, dates, labels, and buttons. Structure is carried by hairlines (`--rule`) and near-square radii, not by shadow and float; a heavy `--color-fg-bold` rule opens a section, a `--color-border` hairline divides within one
+- **Design system**: Three type roles, and every element should pick one deliberately: `--font-display` (Bricolage Grotesque) for names and headings, `--font-body` (Newsreader) for prose, and `--font-mono` (JetBrains Mono) for data, dates, labels, and buttons. Structure is carried by hairlines (`--rule`) and near-square radii, not by shadow and float. A heavy `--color-fg-bold` rule opens a section; a `--color-border` hairline divides within one
 - **Page measures are semantic**: use `--measure-wide` for split hero compositions, `--measure-page` for default pages/lists/footer, and `--measure-read` for continuous prose and compact data views. Component constraints such as portraits, controls, and short status messages may still use their own intrinsic measure; do not create a new page width for each route
 - **Signal colour discipline**: `--color-accent` (ultramarine) is for structure and links. `--color-signal` (amber) is reserved for values that are live or in progress — the ticking age, a role with no end date. Using it decoratively is what makes the rest of it stop meaning anything. `--color-signal` is the text-safe value; use `--color-signal-mark` for non-text marks only
 - **Link accents and button fills are different tokens**: `--color-accent` is tuned for text on the page background and is far too light in dark mode to sit behind white text (it measured 2.67:1). Filled controls use `--color-accent-fill` / `--color-accent-fill-hover` with `--color-on-accent`

--- a/README.md
+++ b/README.md
@@ -26,7 +26,17 @@ are personal, so a fork needs a full rebrand.
 
 ## Get started
 
-### Option 1: Local development
+### With a coding agent
+
+Open your fork in a coding agent and ask:
+
+```text
+Read AGENTS.md, use the Node version in .nvmrc, install the locked
+dependencies, and start the development server. Do not change the site yet.
+Tell me the local URL and report any setup failure with its exact output.
+```
+
+### Manual setup
 
 With [GitHub CLI](https://cli.github.com/) and
 [nvm](https://github.com/nvm-sh/nvm) installed:
@@ -42,7 +52,7 @@ npm run dev
 If you use another version manager, choose a release accepted by `engines.node`
 in `package.json`.
 
-### Option 2: GitHub Codespaces
+### GitHub Codespaces
 
 1. Click **Fork** at the top of this page.
 2. In your fork, click **Code**, choose **Codespaces**, then create a codespace.
@@ -54,13 +64,29 @@ npm ci
 npm run dev
 ```
 
-No local tool installation is required.
+Codespaces provides the tools, so you do not need to install them locally.
 
-## Adapt it
+## Adapt it with a coding agent
 
-The **[adapting guide](./docs/adapting-guide.md)** lists the content, links,
-metadata, images, and styles a fork should replace. Finish by searching for
-upstream details and reviewing a production build.
+When you are ready to customize the site, give the agent your résumé, profile
+details, links, images, and intended site URL. Try:
+
+```text
+Read AGENTS.md and docs/adapting-guide.md, set up the repository, then rebrand
+this fork for [NAME] with the details and assets I provide. Work on a topic
+branch and preserve the current routes and design unless I say otherwise.
+Inventory the existing posts, external writing, résumé, and projects before
+changing the shared identity. Do not relabel that content as mine. Ask whether
+unmatched personal content should keep its original attribution, be replaced,
+or be removed. Use the guide's reference map to update every identity surface
+and generated asset. Search for remaining upstream details and run the full
+validation suite. Do not commit, push, merge, change GitHub settings, create
+secrets, or modify DNS. Report the external steps that remain.
+```
+
+The **[adapting guide](./docs/adapting-guide.md)** has focused prompts for
+writing, feature removal, visual changes, and deployment, plus a map of the
+files an agent should inspect.
 
 ## Commands
 
@@ -82,7 +108,8 @@ build, and the exported site on every pull request.
 ## Deploy
 
 Pushes to `main` deploy the same static build that CI validates. See the
-[adapting guide](./docs/adapting-guide.md#deployment) for URL and domain setup.
+[adapting guide](./docs/adapting-guide.md#deployment-reference) for URL and
+domain setup.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,62 +1,66 @@
-# Michael D'Angelo — Personal Site
+# Michael D'Angelo: Personal Site
 
 [![Build Status](https://img.shields.io/github/actions/workflow/status/mldangelo/personal-site/node.js.yml?branch=main)](https://github.com/mldangelo/personal-site/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/mldangelo/personal-site?style=social)](https://github.com/mldangelo/personal-site/stargazers)
 [![GitHub Forks](https://img.shields.io/github/forks/mldangelo/personal-site?style=social)](https://github.com/mldangelo/personal-site/network/members)
 
-The source for [mldangelo.com](https://mldangelo.com): a deliberately bespoke
-portfolio, résumé, archive, and writing site built with
+The source for [mldangelo.com](https://mldangelo.com), a portfolio, résumé,
+project archive, and writing site built with
 [Next.js](https://nextjs.org/), [React](https://react.dev/),
 [TypeScript](https://www.typescriptlang.org/), and
 [Tailwind CSS](https://tailwindcss.com/).
 
-The architecture is reusable and MIT-licensed, but the content and visual
-system are personal. Fork it as a starting point, not as a one-hour
-fill-in-the-blanks theme.
+The architecture is reusable and MIT licensed. The content and visual design
+are personal, so a fork needs a full rebrand.
 
 **[Visit the live site →](https://mldangelo.com)**
 
-## What Is Here
+## What is here
 
 - A statically exported Next.js 16 site deployed to GitHub Pages.
 - A responsive light/dark design system built from semantic CSS tokens.
-- Markdown writing with draft isolation, RSS, sitemap, canonical metadata, and
-  measured article images.
-- A filterable résumé whose complete content remains available to print.
-- Export-level verification for broken routes, fragments, metadata, duplicate
-  IDs, draft leaks, and missing assets.
-- Unit, accessibility-oriented component, metadata, and content-pipeline tests.
+- Markdown writing with drafts, RSS, and page metadata.
+- A filterable résumé that still prints in full.
+- Tests for components, content, metadata, and the final static export.
 
-## Get Started
+## Get started
 
-### Option 1: Local Development
+### Option 1: Local development
+
+With [GitHub CLI](https://cli.github.com/) and
+[nvm](https://github.com/nvm-sh/nvm) installed:
 
 ```bash
 gh repo fork mldangelo/personal-site --clone
 cd personal-site
+nvm install
 npm ci
 npm run dev
 ```
 
-Requires [GitHub CLI](https://cli.github.com/) and Node.js 22.13 or newer.
-[nvm](https://github.com/nvm-sh/nvm) is recommended—`nvm use` picks up the
-version in `.nvmrc`, which is what CI and the deployed build run.
+If you use another version manager, choose a release accepted by `engines.node`
+in `package.json`.
 
 ### Option 2: GitHub Codespaces
 
-1. Click **Fork** at the top of this page
-2. In your fork, click **Code** → **Codespaces** → **Create codespace**
-3. Run `npm run dev`
+1. Click **Fork** at the top of this page.
+2. In your fork, click **Code**, choose **Codespaces**, then create a codespace.
+3. Run:
 
-No local setup needed. Everything runs in your browser.
+```bash
+nvm install
+npm ci
+npm run dev
+```
 
-## Adapt It
+No local tool installation is required.
 
-The **[adapting guide](./docs/adapting-guide.md)** maps the authored profile,
-content, metadata, imagery, and theme surfaces that need to change together.
-The site intentionally centralizes many facts, but a complete rebrand still
-deserves a repository-wide search and a production-export review.
+## Adapt it
+
+The **[adapting guide](./docs/adapting-guide.md)** lists the content, links,
+metadata, images, and styles a fork should replace. Finish by searching for
+upstream details and reviewing a production build.
 
 ## Commands
 
@@ -72,22 +76,18 @@ npm run og              # Regenerate the share card
 npm run og:check        # Verify the committed share card is current
 ```
 
-CI runs `lint`, `format:check`, `type-check`, `og:check`, the test suite, and
-`verify-export` against every build. Running `npm run format` before committing
-is the one step people forget—the format check is a hard gate.
+CI checks formatting, linting, types, the share card, tests, the production
+build, and the exported site on every pull request.
 
 ## Deploy
 
-Pushes to `main` deploy the same Linux export artifact that passed the full CI
-graph, built on the Node version in `.nvmrc`. See the
-[adapting guide](./docs/adapting-guide.md#deployment) for domain setup.
+Pushes to `main` deploy the same static build that CI validates. See the
+[adapting guide](./docs/adapting-guide.md#deployment) for URL and domain setup.
 
 ## Contributing
 
-Contributions are welcome. If you find a bug or want to improve the reusable
-parts of the site, please open a PR.
-
-See [contributing guide](./docs/contributing.md) and [design goals](./docs/design-goals.md).
+See the [contributing guide](./docs/contributing.md) for setup, branch and commit
+conventions, validation, and pull request expectations.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ portfolio, résumé, archive, and writing site built with
 [TypeScript](https://www.typescriptlang.org/), and
 [Tailwind CSS](https://tailwindcss.com/).
 
-The architecture is reusable and MIT-licensed, but the content and “Ground
-Station” visual system are personal. Fork it as a starting point, not as a
-one-hour fill-in-the-blanks theme.
+The architecture is reusable and MIT-licensed, but the content and visual
+system are personal. Fork it as a starting point, not as a one-hour
+fill-in-the-blanks theme.
 
 **[Visit the live site →](https://mldangelo.com)**
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ npm ci
 npm run dev
 ```
 
-Requires [GitHub CLI](https://cli.github.com/) and Node.js 20+ ([nvm](https://github.com/nvm-sh/nvm) recommended).
+Requires [GitHub CLI](https://cli.github.com/) and Node.js 22.13 or newer.
+[nvm](https://github.com/nvm-sh/nvm) is recommended—`nvm use` picks up the
+version in `.nvmrc`, which is what CI and the deployed build run.
 
 ### Option 2: GitHub Codespaces
 
@@ -66,12 +68,18 @@ npm run type-check      # Run TypeScript
 npm test                # Run Vitest
 npm run build           # Build the production static export
 npm run verify-export   # Inspect the generated HTML and XML
+npm run og              # Regenerate the share card
+npm run og:check        # Verify the committed share card is current
 ```
+
+CI runs `lint`, `format:check`, `type-check`, `og:check`, the test suite, and
+`verify-export` against every build. Running `npm run format` before committing
+is the one step people forget—the format check is a hard gate.
 
 ## Deploy
 
-Pushes to `main` deploy the same Linux/Node 22 export artifact that passed the
-full CI graph. See the
+Pushes to `main` deploy the same Linux export artifact that passed the full CI
+graph, built on the Node version in `.nvmrc`. See the
 [adapting guide](./docs/adapting-guide.md#deployment) for domain setup.
 
 ## Contributing

--- a/app/styles/tokens/colors.css
+++ b/app/styles/tokens/colors.css
@@ -1,5 +1,5 @@
 /* ========================================
-   COLOR TOKENS — "Ground Station"
+   COLOR TOKENS
    Warm neutral paper, ultramarine structure,
    amber reserved for live instrument readouts.
    ======================================== */

--- a/docs/adapting-guide.md
+++ b/docs/adapting-guide.md
@@ -11,10 +11,15 @@ sync.
 
 ## Before You Start
 
+You need Node.js 22.13 or newer. The repository develops on the version pinned
+in `.nvmrc`, which is also what CI and the deployed build use; with
+[nvm](https://github.com/nvm-sh/nvm) installed, `nvm use` selects it.
+
 1. Fork and clone the repository
-2. Run `npm ci` then `npm run dev`
-3. Open [http://localhost:3000](http://localhost:3000) to see the site
-4. Keep the dev server running—changes appear instantly
+2. Run `nvm use` (or otherwise switch to Node 22.13+)
+3. Run `npm ci` then `npm run dev`
+4. Open [http://localhost:3000](http://localhost:3000) to see the site
+5. Keep the dev server running—changes appear instantly
 
 ## Customization Checklist
 
@@ -55,9 +60,9 @@ Work through these steps in order for the smoothest experience.
 | Project entries | `src/data/projects.ts`    |
 | Project images  | `public/images/projects/` |
 
-### Step 5: Blog/Writing (Optional)
+### Step 5: Blog/Writing
 
-The site includes a blog at `/writing/` with an RSS feed. You can use it, customize it, or remove it entirely.
+The site includes a blog at `/writing/` with an RSS feed.
 
 **To add posts**, create Markdown files in `content/writing/`. The filename becomes the URL slug (for example, `my-post.md` becomes `/writing/my-post/`).
 
@@ -66,18 +71,42 @@ The site includes a blog at `/writing/` with an RSS feed. You can use it, custom
 title: 'Your Post Title'
 date: '2026-01-15'
 description: 'A brief description for previews and SEO.'
+image: /images/writing/optional-share-image.png
+imageAlt: 'Describes the image for screen readers and as a fallback'
+draft: true
 ---
 
 Your content here...
 ```
 
-**To disable the blog entirely:**
+Only `title`, `date`, and `description` are required. `image` and `imageAlt`
+set the post's share card and travel together—an image without alt text is an
+accessibility gap. `draft: true` keeps a post visible in development and out of
+the production export entirely, including the sitemap and feed.
 
-```bash
-rm -rf app/writing app/feed.xml content/writing
-```
+**Keep at least one published post.** With an empty `content/writing/`,
+`generateStaticParams()` returns nothing and the static export fails with
+`Page "/writing/[slug]" is missing "generateStaticParams()"`—an error that
+never mentions posts. Replace the example posts rather than emptying the
+directory.
 
-Then remove the "Writing" link from `src/data/routes.ts`.
+**To hide the blog** without removing it, delete the `/writing` entry from
+`src/data/routes.ts`. The routes still build and remain reachable by URL, but
+they leave the navigation.
+
+**Removing the blog outright is a refactor, not a delete.** The content is
+woven into the homepage, sitemap, schema, and export verifier, so budget real
+time for it. Expect to touch:
+
+| Area         | Files                                                                                                      |
+| ------------ | ---------------------------------------------------------------------------------------------------------- |
+| Routes       | `app/writing/`, `app/feed.xml/`, `content/writing/`                                                        |
+| Data loaders | `src/lib/posts.ts`, `src/lib/writing.ts`, `src/data/writing.ts`                                            |
+| Consumers    | `app/page.tsx` (the "Latest writing" section), `app/sitemap.ts`, `src/lib/schema.ts`, `src/data/routes.ts` |
+| Verification | `scripts/verify-export.mjs`, plus the tests covering each of the above                                     |
+
+Unless you specifically need those routes gone, hiding the blog is the cheaper
+and far less error-prone option.
 
 ### Step 6: Branding & Theme
 
@@ -116,6 +145,20 @@ npm run og:check
 npm run build
 npm run verify-export
 ```
+
+**Some tests assert this site's specific content, so replacing it will fail
+them.** That is expected, not a sign you broke something—update the
+expectations to match your own content:
+
+| If you change             | Update                                                                                                         |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| The posts                 | `app/__tests__/content-ia.test.tsx`, `app/writing/[slug]/page.test.ts`, `app/feed.xml/__tests__/route.test.ts` |
+| The navigation routes     | `src/components/__tests__/Template/Navigation.test.tsx`                                                        |
+| Profile, résumé, projects | the matching suites under `src/data/__tests__/`                                                                |
+
+Tests that assert structure rather than content—metadata completeness, canonical
+URLs, draft isolation, duplicate IDs—should keep passing. If one of those fails,
+it is worth reading closely.
 
 ## Deployment
 
@@ -170,14 +213,16 @@ Edit `app/styles/tokens/colors.css`. Its `:root` and `[data-theme='dark']` block
 
 ## Troubleshooting
 
-| Problem                    | Solution                                                   |
-| -------------------------- | ---------------------------------------------------------- |
-| Port 3000 in use           | `npm run dev -- -p 3001`                                   |
-| Styles not updating        | Hard refresh: Cmd+Shift+R (Mac) or Ctrl+Shift+R (Windows)  |
-| Images not appearing       | Use `/images/...` not `public/images/...` in code          |
-| Build failing              | Run `npm run lint`, `npm run type-check`, and `npm test`   |
-| CSS 404 or wrong path      | Check `homepage` in `package.json` matches your deploy URL |
-| Git line endings (Windows) | `git config core.autocrlf input`                           |
+| Problem                            | Solution                                                                                                                                                                            |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Port 3000 in use                   | `npm run dev -- -p 3001`                                                                                                                                                            |
+| Styles not updating                | Hard refresh: Cmd+Shift+R (Mac) or Ctrl+Shift+R (Windows)                                                                                                                           |
+| Images not appearing               | Use `/images/...` not `public/images/...` in code                                                                                                                                   |
+| Build failing                      | Run `npm run lint`, `npm run type-check`, and `npm test`                                                                                                                            |
+| `npm ci` refuses to install        | You are on Node older than 22.13; run `nvm use`                                                                                                                                     |
+| `missing "generateStaticParams()"` | `content/writing/` has no published posts—keep at least one                                                                                                                         |
+| Assets 404 on a project site       | Repository sites are served from `/<repo>/`. The Pages workflow injects that basePath via `actions/configure-pages`; a custom domain in `public/CNAME` serves from the root instead |
+| Git line endings (Windows)         | `git config core.autocrlf input`                                                                                                                                                    |
 
 ## Getting Help
 

--- a/docs/adapting-guide.md
+++ b/docs/adapting-guide.md
@@ -1,12 +1,14 @@
 # Adapting This Website
 
-This repository can be a starting point for another personal site, but it is
-not a blank theme. Forks need to replace the content, identity, links, metadata,
-and generated assets.
+A coding agent can handle the repository changes once you provide your
+identity, content, assets, and target URL. You decide what to publish, and
+account or DNS changes still require your approval.
 
-## Before you start
+## Set up the workspace
 
-With [nvm](https://github.com/nvm-sh/nvm) installed:
+Ask your agent to use the Node version in `.nvmrc`, install the locked
+dependencies, and start the development server. To set up the fork manually,
+run:
 
 ```bash
 git clone https://github.com/YOUR-USER/personal-site.git
@@ -19,11 +21,86 @@ npm run dev
 Open [http://localhost:3000](http://localhost:3000). If you use another version
 manager, choose a release accepted by `engines.node` in `package.json`.
 
-## Replace the content
+## Copyable requests
+
+Use the full rebrand prompt in the
+[README](../README.md#adapt-it-with-a-coding-agent) for a first pass. For a
+smaller change, copy one of these.
+
+### Manage writing
+
+```text
+Read AGENTS.md and work on a topic branch. Do not commit, push, merge, or change
+account settings unless I explicitly authorize it.
+Manage writing for this site as follows: [ADD, UPDATE, OR REMOVE CONTENT].
+Use content/writing/ for local posts and src/data/writing.ts for external
+links. Preserve draft isolation, RSS, the homepage writing section, metadata,
+and valid post slugs. Pair each frontmatter `image` with `imageAlt`, and give
+Markdown images descriptive alt text. Keep at least one published post unless I
+asked you to remove writing completely. Run the full validation suite and
+report unresolved content decisions or validation failures.
+```
+
+### Remove a page or feature
+
+```text
+Read AGENTS.md and work on a topic branch. Do not commit, push, merge, or change
+account settings unless I explicitly authorize it.
+Remove [PAGE OR FEATURE] completely. Before deleting anything, trace its route,
+navigation entry, homepage references, data imports, sitemap entries, schema,
+feed integration, styles, tests, and export verifier checks. Do not change
+unrelated routes or URLs. Run the full validation suite and report any
+remaining references.
+```
+
+### Change the visual identity
+
+```text
+Read AGENTS.md and work on a topic branch. Do not commit, push, merge, or change
+account settings unless I explicitly authorize it.
+Rebrand the visual identity using [COLORS], [FONTS], [PORTRAIT], and
+[DESIGN DIRECTION]. Work through the existing semantic tokens. Keep light and
+dark themes, print behavior, accessibility, and the signal-color rules intact.
+Regenerate and verify the share card, then run the full validation suite.
+```
+
+### Prepare deployment
+
+```text
+Read AGENTS.md and work on a topic branch. Do not commit, push, merge, or change
+account settings unless I explicitly authorize it.
+Read the deployment reference in docs/adapting-guide.md, then prepare this
+repository for [FINAL URL] on [HOST]. Make every required repository change,
+run the full validation suite, and inspect out/. Do not create secrets or
+modify DNS. Report the exact external steps that remain.
+```
+
+### Add a social link
+
+```text
+Read AGENTS.md and work on a topic branch. Do not commit, push, merge, or change
+account settings unless I explicitly authorize it.
+Add my [PLATFORM] profile at [URL]. Follow the existing src/data/contact.ts
+pattern and reuse the installed Font Awesome packages. Update affected tests,
+run the relevant checks, and show me the diff.
+```
+
+### Add Google Analytics
+
+```text
+Read AGENTS.md and work on a topic branch. Do not commit, push, merge, or change
+account settings unless I explicitly authorize it.
+Configure this fork to use GA4 measurement ID [G-XXXXXXX]. Use the existing
+NEXT_PUBLIC_GA_TRACKING_ID integration. Put the local value in .env.local and
+keep that file untracked. Tell me which GitHub repository variable production
+needs.
+```
+
+## Reference map
 
 ### Identity and contact details
 
-Start with the shared data, then update hard-coded text and links.
+Identity data starts in shared files, but some text and links are hard-coded.
 
 | Content                                                        | Location                                                            |
 | -------------------------------------------------------------- | ------------------------------------------------------------------- |
@@ -40,8 +117,8 @@ Start with the shared data, then update hard-coded text and links.
 | Repository statistics and GitHub API URL                       | `src/components/Stats/Site.tsx`, `src/data/stats/site.ts`           |
 | Countries map                                                  | `src/data/stats/personal.tsx`                                       |
 
-Page titles and descriptions also contain personal copy. Check `app/layout.tsx`
-and the `page.tsx` files under `app/`. Structured data is assembled in
+Page titles and descriptions also contain personal copy in `app/layout.tsx` and
+the `page.tsx` files under `app/`. Structured data is assembled in
 `src/lib/schema.ts`.
 
 ### About, résumé, and projects
@@ -56,8 +133,8 @@ and the `page.tsx` files under `app/`. Structured data is assembled in
 | Projects       | `src/data/projects.ts`       |
 | Project images | `public/images/projects/`    |
 
-Keep current role details consistent across the profile, homepage, résumé, and
-page metadata.
+The current role appears in the profile, homepage, résumé, and page metadata.
+Update those together.
 
 ### Writing
 
@@ -69,9 +146,9 @@ Writing comes from two places:
 Both sources appear on `/writing/`. Dated entries can also appear on the
 homepage and in the RSS feed.
 
-To add a local post, create a Markdown file. Its filename becomes the URL slug,
-so `my-post.md` becomes `/writing/my-post/`. Use lowercase letters and numbers
-separated by single hyphens.
+Local posts are Markdown files. The filename becomes the URL slug, so
+`my-post.md` becomes `/writing/my-post/`. Valid filenames use lowercase letters
+and numbers separated by single hyphens.
 
 ```markdown
 ---
@@ -83,29 +160,29 @@ description: 'A short description for previews and search results.'
 Your content here.
 ```
 
-The required fields are `title`, `date`, and `description`. Set `draft: true`
-to show a post during development without including it in the production
-export. An optional `image` must be a root-relative path under `public/` and
-must be paired with `imageAlt`.
+The required fields are `title`, `date`, and `description`. `draft: true` shows
+a post during development without including it in the production export. An
+optional `image` must be a root-relative path under `public/` and must be paired
+with `imageAlt`.
 
-Keep at least one published post. The static export cannot build the dynamic
-post route when `generateStaticParams()` has no published slugs.
+The production export requires at least one published post. It cannot build the
+dynamic post route when `generateStaticParams()` has no published slugs.
 
 Removing the Writing link from `src/data/routes.ts` only hides it from
 navigation. The homepage still promotes writing, and the routes remain
 available by URL.
 
-To remove writing completely, first find every consumer:
+Full removal requires a consumer search before any files are deleted:
 
 ```bash
 rg -n -i "writing|feed\\.xml|getWritingItems|getAllPosts" app src scripts
 ```
 
-Expect to remove or update the writing routes, feed, content loaders, homepage
+A complete removal touches the writing routes, feed, content loaders, homepage
 section, sitemap, schema, export verifier, styles, and tests. Run a production
 build after the refactor.
 
-## Replace the visual identity
+### Visual identity
 
 | Setting                    | Location                                |
 | -------------------------- | --------------------------------------- |
@@ -116,36 +193,36 @@ build after the refactor.
 | Default metadata           | `app/layout.tsx`, `src/lib/metadata.ts` |
 | Share-card generator       | `scripts/generate-og.mjs`               |
 
-After changing profile fields used on the share card or changing its design,
-run:
+After changing profile fields on the share card or its design, run:
 
 ```bash
 npm run og
 npm run og:check
 ```
 
-Commit both `public/og.png` and `public/og.meta.json`.
+`npm run og` updates `public/og.png` and `public/og.meta.json`. The image and
+metadata must stay in sync.
 
-## Search for upstream details
+## Audit the result
 
-Search for the current name, domain, handle, employer, and repository before
-publishing:
+Require the final search output and validation results, not only a completion
+claim. This search covers the current name, domain, handle, employer, and
+repository:
 
 ```bash
 rg -n -i "Michael|mldangelo|dangelosaurus|mldangelo\\.com|OpenAI|Promptfoo" \
   app content public scripts src package.json README.md
 ```
 
-Repeat the search with any other upstream names or URLs you find. This catches
-details in page descriptions, tests, images, and links that a checklist can
-miss.
+Repeat it with any other upstream names or URLs the search uncovers. This
+catches details in page descriptions, tests, images, and links that a checklist
+can miss.
 
-Some tests assert the site's public content. Search for the old exact text and
-update those expectations when the corresponding content changes. Do not
-weaken structural checks for metadata, canonical URLs, draft isolation,
-accessibility, or export integrity.
+Some tests assert the site's public content, so exact-text expectations may
+need updates. Do not weaken structural checks for metadata, canonical URLs,
+draft isolation, accessibility, or export integrity.
 
-Run the full validation suite:
+The full validation suite is:
 
 ```bash
 npm run format
@@ -157,83 +234,67 @@ npm run build
 npm run verify-export
 ```
 
-## Deployment
+## Deployment reference
 
-### GitHub Pages
+### Changes inside the repository
 
-1. Set `SITE_URL` in `src/lib/utils.ts` to the final public URL without a
-   trailing slash.
-2. Set `homepage` in `package.json` to the same URL with a trailing slash.
-3. In **Settings > Pages**, choose **GitHub Actions** as the source.
-4. Push to `main`.
+A coding agent can prepare and verify the repository:
 
-The site works as written at a root URL, such as a custom domain or a
-`YOUR-USER.github.io` user site. A project site at
-`https://YOUR-USER.github.io/personal-site/` needs more work. The workflow
+- Set `SITE_URL` in `src/lib/utils.ts` to the final public URL without a
+  trailing slash.
+- Set `homepage` in `package.json` to the same URL with a trailing slash.
+- Update `public/robots.txt` and other URL-bearing files.
+- Build the site and inspect `out/`.
+
+The site works as written at a root URL, such as a custom domain. A GitHub user
+or organization site also has a root URL, but its repository must be named
+[`<owner>.github.io`](https://docs.github.com/en/pages/getting-started-with-github-pages/what-is-github-pages).
+A fork left under another repository name is a project site at
+`https://YOUR-USER.github.io/REPOSITORY/` and needs more work. The workflow
 injects Next's `basePath`, but raw asset paths and absolute URLs created by the
 application still assume a root deployment. Updating `SITE_URL` and `homepage`
 alone is not enough for that case.
 
-### Custom domain
+### Actions outside the repository
 
-Add the domain in **Settings > Pages**, then configure its DNS records using
-[GitHub's custom-domain guide](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site).
-Update `SITE_URL` and `homepage` to the custom URL.
+GitHub settings, deployment accounts, and DNS changes require account access.
+An agent can perform them only with explicit authorization.
 
-This repository publishes through a custom GitHub Actions workflow. GitHub
-ignores `public/CNAME` for this publishing method, so delete the upstream file
-from your fork.
+For GitHub Pages:
 
-### Other static hosts
+1. In the fork's **Actions** tab, enable workflows. GitHub
+   [disables workflows in forks by default](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflows-in-forked-repositories).
+2. To use the default root URL without a custom domain, rename the fork to
+   `YOUR-USER.github.io` in **Settings > General**.
+3. In **Settings > Pages**, choose **GitHub Actions** as the source.
+4. For a custom domain,
+   [verify the domain](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/verifying-your-custom-domain-for-github-pages)
+   in your profile or organization settings before attaching it to the
+   repository.
+5. Add the custom domain in **Settings > Pages** before changing its routing
+   records.
+6. Configure DNS using
+   [GitHub's custom-domain guide](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site).
+7. After reviewing the branch, push or merge it to `main` to deploy.
 
-Run `npm run build` and deploy the generated `out/` directory to the host's
-root. A subpath deployment also needs a matching Next `basePath` and an audit of
-raw asset and absolute URL construction. `SITE_URL` alone does not configure
-that path.
+GitHub ignores `public/CNAME` when a custom Actions workflow publishes the
+site. The agent can delete the upstream file from the fork.
 
-## Common changes
-
-### Remove a page
-
-Deleting a route folder does not remove its other references. Search for its
-path, label, component names, and data imports first. Update navigation,
-`app/sitemap.ts`, schema, styles, and tests as applicable.
-
-### Add a social link
-
-In `src/data/contact.ts`, import a Font Awesome icon and add an item:
-
-```typescript
-import { faYoutube } from '@fortawesome/free-brands-svg-icons/faYoutube';
-
-{ link: 'https://youtube.com/@you', label: 'YouTube', icon: faYoutube },
-```
-
-### Change theme colors
-
-Edit the `:root` and `[data-theme='dark']` blocks in
-`app/styles/tokens/colors.css`. Use `--color-accent` for links,
-`--color-accent-fill` for filled controls, and `--color-signal` only for live
-values.
-
-### Add Google Analytics
-
-Copy `.env.example` to `.env.local` and set:
-
-```text
-NEXT_PUBLIC_GA_TRACKING_ID=G-XXXXXXX
-```
+For another static host, the agent can build `out/` and prepare the deployment.
+Uploading it to the hosting account still requires explicit authorization. A
+subpath deployment also needs a matching Next `basePath` and an audit of raw
+assets and absolute URL construction.
 
 ## Troubleshooting
 
-| Problem                                 | Check                                                                                 |
-| --------------------------------------- | ------------------------------------------------------------------------------------- |
-| `EBADENGINE` warning or install failure | Run `nvm install`, then retry `npm ci`                                                |
-| Port 3000 is in use                     | Run `npm run dev -- -p 3001`                                                          |
-| Images do not appear                    | Use a URL such as `/images/photo.jpg`, not `public/images/photo.jpg`                  |
-| `missing "generateStaticParams()"`      | Keep at least one published Markdown post                                             |
-| Assets return 404 on a project site     | Review the repository subpath limitation in the [GitHub Pages section](#github-pages) |
-| The export verifier fails               | Run `npm run build` first, then inspect the named file or route                       |
+| Problem                                 | Check                                                                                         |
+| --------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `EBADENGINE` warning or install failure | Run `nvm install`, then retry `npm ci`                                                        |
+| Port 3000 is in use                     | Run `npm run dev -- -p 3001`                                                                  |
+| Images do not appear                    | Use a URL such as `/images/photo.jpg`, not `public/images/photo.jpg`                          |
+| `missing "generateStaticParams()"`      | Keep at least one published Markdown post                                                     |
+| Assets return 404 on a project site     | Review the repository subpath limitation in the [deployment reference](#deployment-reference) |
+| The export verifier fails               | Run `npm run build` first, then inspect the named file or route                               |
 
 ## Getting help
 

--- a/docs/adapting-guide.md
+++ b/docs/adapting-guide.md
@@ -1,140 +1,151 @@
 # Adapting This Website
 
-Fork this repository as a starting point for your own personal site. The code
-is designed to be adapted, but the content and visual identity are intentionally
-specific; budget time for a full rebrand rather than treating it as a generic
-fill-in-the-blanks theme.
+This repository can be a starting point for another personal site, but it is
+not a blank theme. Forks need to replace the content, identity, links, metadata,
+and generated assets.
 
-An AI assistant can help with the mechanical edits, but use the checklist below
-to verify that facts, routes, metadata, images, and generated assets stay in
-sync.
+## Before you start
 
-## Before You Start
+With [nvm](https://github.com/nvm-sh/nvm) installed:
 
-You need Node.js 22.13 or newer. The repository develops on the version pinned
-in `.nvmrc`, which is also what CI and the deployed build use; with
-[nvm](https://github.com/nvm-sh/nvm) installed, `nvm use` selects it.
+```bash
+git clone https://github.com/YOUR-USER/personal-site.git
+cd personal-site
+nvm install
+npm ci
+npm run dev
+```
 
-1. Fork and clone the repository
-2. Run `nvm use` (or otherwise switch to Node 22.13+)
-3. Run `npm ci` then `npm run dev`
-4. Open [http://localhost:3000](http://localhost:3000) to see the site
-5. Keep the dev server running—changes appear instantly
+Open [http://localhost:3000](http://localhost:3000). If you use another version
+manager, choose a release accepted by `engines.node` in `package.json`.
 
-## Customization Checklist
+## Replace the content
 
-Work through these steps in order for the smoothest experience.
+### Identity and contact details
 
-### Step 1: Identity & Contact
+Start with the shared data, then update hard-coded text and links.
 
-| What to change          | File                                    | Notes                                                |
-| ----------------------- | --------------------------------------- | ---------------------------------------------------- |
-| Profile facts and email | `src/data/profile.json`                 | Shared by contact links, stats, metadata, and OG     |
-| Site URL and author     | `src/lib/utils.ts`, `package.json`      | Keep `SITE_URL` and `homepage` aligned               |
-| Social links            | `src/data/contact.ts`                   | Add or remove platforms as needed                    |
-| Portrait                | `public/images/me.jpg`                  | Use a square image; the current asset is 1024×1024px |
-| Homepage copy           | `src/components/Template/Hero.tsx`      | Name, role, tagline, and calls to action             |
-| Footer                  | `src/components/Template/Footer.tsx`    | Identity, source link, and copyright                 |
-| Resume introduction     | `app/resume/page.tsx`                   | Keep this summary aligned with the homepage          |
-| SEO defaults            | `app/layout.tsx`, `src/lib/metadata.ts` | Keywords and shared page-card metadata               |
+| Content                                                        | Location                                                            |
+| -------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Name, role, employer, location, email, and personal statistics | `src/data/profile.json`                                             |
+| Canonical URL, social handle, descriptions, and image settings | `src/lib/utils.ts`                                                  |
+| Social links                                                   | `src/data/contact.ts`                                               |
+| Homepage biography and employer links                          | `src/components/Template/Hero.tsx`                                  |
+| Logo initials                                                  | `src/components/Template/Navigation.tsx`                            |
+| Footer source link                                             | `src/components/Template/Footer.tsx`                                |
+| Portrait and its alt text                                      | `public/images/me.jpg`, `src/components/Template/ThemePortrait.tsx` |
+| Favicon files and web app name                                 | `public/images/favicon/`                                            |
+| Sitemap URL for crawlers                                       | `public/robots.txt`                                                 |
+| RSS title and description                                      | `app/feed.xml/route.ts`                                             |
+| Repository statistics and GitHub API URL                       | `src/components/Stats/Site.tsx`, `src/data/stats/site.ts`           |
+| Countries map                                                  | `src/data/stats/personal.tsx`                                       |
 
-### Step 2: About Page
+Page titles and descriptions also contain personal copy. Check `app/layout.tsx`
+and the `page.tsx` files under `app/`. Structured data is assembled in
+`src/lib/schema.ts`.
 
-| What to change         | File                |
-| ---------------------- | ------------------- |
-| Bio, intro, everything | `src/data/about.ts` |
+### About, résumé, and projects
 
-### Step 3: Resume
+| Content        | Location                     |
+| -------------- | ---------------------------- |
+| About page     | `src/data/about.ts`          |
+| Work history   | `src/data/resume/work.ts`    |
+| Education      | `src/data/resume/degrees.ts` |
+| Skills         | `src/data/resume/skills.ts`  |
+| Courses        | `src/data/resume/courses.ts` |
+| Projects       | `src/data/projects.ts`       |
+| Project images | `public/images/projects/`    |
 
-| What to change      | File                         |
-| ------------------- | ---------------------------- |
-| Work experience     | `src/data/resume/work.ts`    |
-| Education           | `src/data/resume/degrees.ts` |
-| Skills & categories | `src/data/resume/skills.ts`  |
-| Courses (optional)  | `src/data/resume/courses.ts` |
+Keep current role details consistent across the profile, homepage, résumé, and
+page metadata.
 
-### Step 4: Projects
+### Writing
 
-| What to change  | File                      |
-| --------------- | ------------------------- |
-| Project entries | `src/data/projects.ts`    |
-| Project images  | `public/images/projects/` |
+Writing comes from two places:
 
-### Step 5: Blog/Writing
+- Markdown posts in `content/writing/`
+- External articles in `src/data/writing.ts`
 
-The site includes a blog at `/writing/` with an RSS feed.
+Both sources appear on `/writing/`. Dated entries can also appear on the
+homepage and in the RSS feed.
 
-**To add posts**, create Markdown files in `content/writing/`. The filename becomes the URL slug (for example, `my-post.md` becomes `/writing/my-post/`).
+To add a local post, create a Markdown file. Its filename becomes the URL slug,
+so `my-post.md` becomes `/writing/my-post/`. Use lowercase letters and numbers
+separated by single hyphens.
 
 ```markdown
 ---
 title: 'Your Post Title'
 date: '2026-01-15'
-description: 'A brief description for previews and SEO.'
-image: /images/writing/optional-share-image.png
-imageAlt: 'Describes the image for screen readers and as a fallback'
-draft: true
+description: 'A short description for previews and search results.'
 ---
 
-Your content here...
+Your content here.
 ```
 
-Only `title`, `date`, and `description` are required. `image` and `imageAlt`
-set the post's share card and travel together—an image without alt text is an
-accessibility gap. `draft: true` keeps a post visible in development and out of
-the production export entirely, including the sitemap and feed.
+The required fields are `title`, `date`, and `description`. Set `draft: true`
+to show a post during development without including it in the production
+export. An optional `image` must be a root-relative path under `public/` and
+must be paired with `imageAlt`.
 
-**Keep at least one published post.** With an empty `content/writing/`,
-`generateStaticParams()` returns nothing and the static export fails with
-`Page "/writing/[slug]" is missing "generateStaticParams()"`—an error that
-never mentions posts. Replace the example posts rather than emptying the
-directory.
+Keep at least one published post. The static export cannot build the dynamic
+post route when `generateStaticParams()` has no published slugs.
 
-**To hide the blog** without removing it, delete the `/writing` entry from
-`src/data/routes.ts`. The routes still build and remain reachable by URL, but
-they leave the navigation.
+Removing the Writing link from `src/data/routes.ts` only hides it from
+navigation. The homepage still promotes writing, and the routes remain
+available by URL.
 
-**Removing the blog outright is a refactor, not a delete.** The content is
-woven into the homepage, sitemap, schema, and export verifier, so budget real
-time for it. Expect to touch:
-
-| Area         | Files                                                                                                      |
-| ------------ | ---------------------------------------------------------------------------------------------------------- |
-| Routes       | `app/writing/`, `app/feed.xml/`, `content/writing/`                                                        |
-| Data loaders | `src/lib/posts.ts`, `src/lib/writing.ts`, `src/data/writing.ts`                                            |
-| Consumers    | `app/page.tsx` (the "Latest writing" section), `app/sitemap.ts`, `src/lib/schema.ts`, `src/data/routes.ts` |
-| Verification | `scripts/verify-export.mjs`, plus the tests covering each of the above                                     |
-
-Unless you specifically need those routes gone, hiding the blog is the cheaper
-and far less error-prone option.
-
-### Step 6: Branding & Theme
-
-| What to change      | File                                 |
-| ------------------- | ------------------------------------ |
-| Colors (light/dark) | `app/styles/tokens/colors.css`       |
-| Type scale          | `app/styles/tokens/typography.css`   |
-| Font families       | `app/fonts.ts`                       |
-| Favicon             | `public/images/favicon/`             |
-| Site metadata/SEO   | `app/layout.tsx`, `src/lib/utils.ts` |
-| Share card          | `scripts/generate-og.mjs`            |
-
-After changing the profile or share-card design, run `npm run og` and commit
-both `public/og.png` and `public/og.meta.json`. The metadata file binds the
-committed image to the generator and profile inputs, so omitting either file
-will fail CI.
-
-### Step 7: Final Cleanup
-
-Search the authored files for the existing name and handle to find any remaining references:
+To remove writing completely, first find every consumer:
 
 ```bash
-rg -n "Michael|mldangelo" . \
-  -g '!node_modules/**' -g '!.next/**' -g '!out/**' \
-  -g '!coverage/**' -g '!.git/**'
+rg -n -i "writing|feed\\.xml|getWritingItems|getAllPosts" app src scripts
 ```
 
-Then format and validate the finished site:
+Expect to remove or update the writing routes, feed, content loaders, homepage
+section, sitemap, schema, export verifier, styles, and tests. Run a production
+build after the refactor.
+
+## Replace the visual identity
+
+| Setting                    | Location                                |
+| -------------------------- | --------------------------------------- |
+| Light and dark colors      | `app/styles/tokens/colors.css`          |
+| Type scale                 | `app/styles/tokens/typography.css`      |
+| Font files and assignments | `app/fonts.ts`                          |
+| Favicon                    | `public/images/favicon/`                |
+| Default metadata           | `app/layout.tsx`, `src/lib/metadata.ts` |
+| Share-card generator       | `scripts/generate-og.mjs`               |
+
+After changing profile fields used on the share card or changing its design,
+run:
+
+```bash
+npm run og
+npm run og:check
+```
+
+Commit both `public/og.png` and `public/og.meta.json`.
+
+## Search for upstream details
+
+Search for the current name, domain, handle, employer, and repository before
+publishing:
+
+```bash
+rg -n -i "Michael|mldangelo|dangelosaurus|mldangelo\\.com|OpenAI|Promptfoo" \
+  app content public scripts src package.json README.md
+```
+
+Repeat the search with any other upstream names or URLs you find. This catches
+details in page descriptions, tests, images, and links that a checklist can
+miss.
+
+Some tests assert the site's public content. Search for the old exact text and
+update those expectations when the corresponding content changes. Do not
+weaken structural checks for metadata, canonical URLs, draft isolation,
+accessibility, or export integrity.
+
+Run the full validation suite:
 
 ```bash
 npm run format
@@ -146,87 +157,85 @@ npm run build
 npm run verify-export
 ```
 
-**Some tests assert this site's specific content, so replacing it will fail
-them.** That is expected, not a sign you broke something—update the
-expectations to match your own content:
-
-| If you change             | Update                                                                                                         |
-| ------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| The posts                 | `app/__tests__/content-ia.test.tsx`, `app/writing/[slug]/page.test.ts`, `app/feed.xml/__tests__/route.test.ts` |
-| The navigation routes     | `src/components/__tests__/Template/Navigation.test.tsx`                                                        |
-| Profile, résumé, projects | the matching suites under `src/data/__tests__/`                                                                |
-
-Tests that assert structure rather than content—metadata completeness, canonical
-URLs, draft isolation, duplicate IDs—should keep passing. If one of those fails,
-it is worth reading closely.
-
 ## Deployment
 
-### GitHub Pages (Recommended)
+### GitHub Pages
 
-1. Update `SITE_URL` in `src/lib/utils.ts` and `homepage` in `package.json`
-2. Set your domain in `public/CNAME` (for example, `yoursite.com`)
-3. In your repo settings, enable GitHub Pages with source: GitHub Actions
-4. Push to `main`—it deploys automatically
+1. Set `SITE_URL` in `src/lib/utils.ts` to the final public URL without a
+   trailing slash.
+2. Set `homepage` in `package.json` to the same URL with a trailing slash.
+3. In **Settings > Pages**, choose **GitHub Actions** as the source.
+4. Push to `main`.
 
-### Custom Domain
+The site works as written at a root URL, such as a custom domain or a
+`YOUR-USER.github.io` user site. A project site at
+`https://YOUR-USER.github.io/personal-site/` needs more work. The workflow
+injects Next's `basePath`, but raw asset paths and absolute URLs created by the
+application still assume a root deployment. Updating `SITE_URL` and `homepage`
+alone is not enough for that case.
 
-1. Purchase a domain from Squarespace Domains, Cloudflare, or Namecheap
-2. Add your domain to `public/CNAME`:
-   ```bash
-   echo "yourdomain.com" > public/CNAME
-   ```
-3. Configure DNS per [GitHub's documentation](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site)
+### Custom domain
 
-### Other Hosts
+Add the domain in **Settings > Pages**, then configure its DNS records using
+[GitHub's custom-domain guide](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site).
+Update `SITE_URL` and `homepage` to the custom URL.
 
-Run `npm run build` and upload the `out/` directory to any static host (Vercel, Netlify, S3, etc.).
+This repository publishes through a custom GitHub Actions workflow. GitHub
+ignores `public/CNAME` for this publishing method, so delete the upstream file
+from your fork.
 
-## Common Tasks
+### Other static hosts
+
+Run `npm run build` and deploy the generated `out/` directory to the host's
+root. A subpath deployment also needs a matching Next `basePath` and an audit of
+raw asset and absolute URL construction. `SITE_URL` alone does not configure
+that path.
+
+## Common changes
 
 ### Remove a page
 
-Delete its folder from `app/` and remove the link from `src/data/routes.ts`.
+Deleting a route folder does not remove its other references. Search for its
+path, label, component names, and data imports first. Update navigation,
+`app/sitemap.ts`, schema, styles, and tests as applicable.
 
-```bash
-rm -rf app/stats  # removes the /stats page
-```
+### Add a social link
 
-### Add a social icon
-
-In `src/data/contact.ts`, import from Font Awesome and add to the array:
+In `src/data/contact.ts`, import a Font Awesome icon and add an item:
 
 ```typescript
 import { faYoutube } from '@fortawesome/free-brands-svg-icons/faYoutube';
-// Add to data array:
+
 { link: 'https://youtube.com/@you', label: 'YouTube', icon: faYoutube },
 ```
 
 ### Change theme colors
 
-Edit `app/styles/tokens/colors.css`. Its `:root` and `[data-theme='dark']` blocks define the semantic `--color-*` variables used throughout the site. Keep links on `--color-accent`, filled controls on `--color-accent-fill`, and reserve `--color-signal` for live values.
+Edit the `:root` and `[data-theme='dark']` blocks in
+`app/styles/tokens/colors.css`. Use `--color-accent` for links,
+`--color-accent-fill` for filled controls, and `--color-signal` only for live
+values.
 
 ### Add Google Analytics
 
-1. Create `.env.local` from the example: `cp .env.example .env.local`
-2. Add your GA4 measurement ID: `NEXT_PUBLIC_GA_TRACKING_ID=G-XXXXXXX`
+Copy `.env.example` to `.env.local` and set:
+
+```text
+NEXT_PUBLIC_GA_TRACKING_ID=G-XXXXXXX
+```
 
 ## Troubleshooting
 
-| Problem                            | Solution                                                                                                                                                                            |
-| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Port 3000 in use                   | `npm run dev -- -p 3001`                                                                                                                                                            |
-| Styles not updating                | Hard refresh: Cmd+Shift+R (Mac) or Ctrl+Shift+R (Windows)                                                                                                                           |
-| Images not appearing               | Use `/images/...` not `public/images/...` in code                                                                                                                                   |
-| Build failing                      | Run `npm run lint`, `npm run type-check`, and `npm test`                                                                                                                            |
-| `npm ci` refuses to install        | You are on Node older than 22.13; run `nvm use`                                                                                                                                     |
-| `missing "generateStaticParams()"` | `content/writing/` has no published posts—keep at least one                                                                                                                         |
-| Assets 404 on a project site       | Repository sites are served from `/<repo>/`. The Pages workflow injects that basePath via `actions/configure-pages`; a custom domain in `public/CNAME` serves from the root instead |
-| Git line endings (Windows)         | `git config core.autocrlf input`                                                                                                                                                    |
+| Problem                                 | Check                                                                                 |
+| --------------------------------------- | ------------------------------------------------------------------------------------- |
+| `EBADENGINE` warning or install failure | Run `nvm install`, then retry `npm ci`                                                |
+| Port 3000 is in use                     | Run `npm run dev -- -p 3001`                                                          |
+| Images do not appear                    | Use a URL such as `/images/photo.jpg`, not `public/images/photo.jpg`                  |
+| `missing "generateStaticParams()"`      | Keep at least one published Markdown post                                             |
+| Assets return 404 on a project site     | Review the repository subpath limitation in the [GitHub Pages section](#github-pages) |
+| The export verifier fails               | Run `npm run build` first, then inspect the named file or route                       |
 
-## Getting Help
+## Getting help
 
-- Open an issue: https://github.com/mldangelo/personal-site/issues
-- Email: hi@mldangelo.com
-
-If you find bugs or unclear instructions, please submit a PR—contributions help everyone.
+Open an [issue](https://github.com/mldangelo/personal-site/issues) when the
+instructions are unclear or appear to be wrong.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -8,6 +8,8 @@ change, open an issue so the approach can be discussed.
 - Keep each pull request focused. Split unrelated changes.
 - Review the [design goals](./design-goals.md).
 - Follow the [Contributor Covenant](https://www.contributor-covenant.org/).
+- If you use a coding agent, have it read [AGENTS.md](../AGENTS.md) and give it
+  a focused task.
 
 ## Set up the project
 
@@ -28,7 +30,8 @@ pull request title so the merged history stays consistent.
 
 ## Validate the change
 
-Run the local equivalents of the checks CI runs:
+Ask your coding agent to run the local equivalents of the checks CI runs, or
+run them yourself:
 
 ```bash
 npm run format
@@ -51,5 +54,7 @@ In the description:
 - Describe how you verified it.
 - Call out any visual, compatibility, or follow-up work.
 
-Before requesting review, inspect the complete diff. Remove unrelated
-formatting changes, debugging code, stale comments, and unused files.
+Before requesting review, inspect the complete diff yourself and confirm any
+validation results reported by a coding agent. Remove unrelated formatting
+changes, debugging code, stale comments, and unused files. State which checks
+you did not run.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,61 +1,55 @@
-# How to Contribute
+# Contributing
 
-Contributions are encouraged. Please feel free to get in touch (I will happily pair program with you), take a look at the [roadmap](./roadmap.md), or open a PR.
+Bug fixes and focused improvements are welcome. Before starting a larger
+change, open an issue so the approach can be discussed.
 
 ## Guidelines
 
-Here are a few recommendations to land PRs quickly.
-
-- Small PRs are better than large PRs. If you do two unrelated things, split your changes into two PRs.
+- Keep each pull request focused. Split unrelated changes.
 - Review the [design goals](./design-goals.md).
-- Respect the [Contributor Covenant](https://www.contributor-covenant.org/).
+- Follow the [Contributor Covenant](https://www.contributor-covenant.org/).
 
-## Setup
+## Set up the project
 
-You need Node.js 22.13 or newer. `nvm use` selects the version in `.nvmrc`,
-which is what CI and the deployed build run.
-
-Work on a topic branch rather than `main`, and title commits with a
-[conventional commit](https://www.conventionalcommits.org/) prefix—`feat:`,
-`fix:`, `chore:`, `docs:`. PR titles use the same prefixes, because merges to
-`main` deploy automatically.
-
-## Before You Open a PR
-
-Run the same checks CI runs:
+With [nvm](https://github.com/nvm-sh/nvm) installed:
 
 ```bash
-npm run format        # must run first — format:check is a hard CI gate
+nvm install
+npm ci
+```
+
+The version in `.nvmrc` is used for development and deployment. Other version
+managers can use any release accepted by `engines.node` in `package.json`.
+
+Create a topic branch rather than committing to `main`. Use a
+[Conventional Commit](https://www.conventionalcommits.org/) prefix such as
+`feat:`, `fix:`, `refactor:`, `docs:`, or `chore:`. Use the same format for the
+pull request title so the merged history stays consistent.
+
+## Validate the change
+
+Run the local equivalents of the checks CI runs:
+
+```bash
+npm run format
 npm run lint
 npm run type-check
 npm test
+npm run og:check
 npm run build
 npm run verify-export
-npm run og:check      # only if you changed the profile or share-card generator
 ```
 
-`npm run format` is the step people forget, and it is the most common reason an
-otherwise good PR shows a red check.
+`npm run verify-export` reads the files produced by `npm run build`, so keep
+that order. Add or update tests when behavior changes.
 
-[AGENTS.md](../AGENTS.md) documents the constraints that are easy to trip
-over—metadata inheritance, draft isolation, the static-export rules, and the
-design system. It is worth skimming before a first PR.
+## Open the pull request
 
-## Preparing a Pull Request
+In the description:
 
-1. Write a good summary in your PR description.
-   - Concisely explain your changes.
-   - Justify why your changes are important.
-   - Explain how to test your change (if not obvious).
-1. Make sure everything runs.
-1. Write tests (if appropriate).
-1. Self review your branch.
-   - Lint your code.
-   - Add comments where appropriate and if things are unclear. Comments should help ensure others not familiar with the problem you're solving will understand your code months or years from now.
-   - Minimize perceptual changes in files that are not relevant to your feature. Remove any extra white-spaces in other files that were added by mistake.
-   - Remove anything unnecessary. Remove extra print statements, commented out blocks of code, unused variables, etc.
-   - Check your spelling.
+- Explain what changed and why.
+- Describe how you verified it.
+- Call out any visual, compatibility, or follow-up work.
 
-## References
-
-- https://github.com/google/eng-practices (Recommended Reading)
+Before requesting review, inspect the complete diff. Remove unrelated
+formatting changes, debugging code, stale comments, and unused files.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -10,6 +10,37 @@ Here are a few recommendations to land PRs quickly.
 - Review the [design goals](./design-goals.md).
 - Respect the [Contributor Covenant](https://www.contributor-covenant.org/).
 
+## Setup
+
+You need Node.js 22.13 or newer. `nvm use` selects the version in `.nvmrc`,
+which is what CI and the deployed build run.
+
+Work on a topic branch rather than `main`, and title commits with a
+[conventional commit](https://www.conventionalcommits.org/) prefix—`feat:`,
+`fix:`, `chore:`, `docs:`. PR titles use the same prefixes, because merges to
+`main` deploy automatically.
+
+## Before You Open a PR
+
+Run the same checks CI runs:
+
+```bash
+npm run format        # must run first — format:check is a hard CI gate
+npm run lint
+npm run type-check
+npm test
+npm run build
+npm run verify-export
+npm run og:check      # only if you changed the profile or share-card generator
+```
+
+`npm run format` is the step people forget, and it is the most common reason an
+otherwise good PR shows a red check.
+
+[AGENTS.md](../AGENTS.md) documents the constraints that are easy to trip
+over—metadata inheritance, draft isolation, the static-export rules, and the
+design system. It is worth skimming before a first PR.
+
 ## Preparing a Pull Request
 
 1. Write a good summary in your PR description.

--- a/docs/design-goals.md
+++ b/docs/design-goals.md
@@ -1,65 +1,47 @@
 # Design Goals
 
-This project attempts to follow these design principles. Feedback and discussion around these are encouraged. Please feel free to submit an issue or get in touch.
+These principles guide changes to the site.
 
-## Simple
+## Easy to fork
 
-1. Someone learning web development should be able to clone this repo and start making it their own within a few minutes.
-2. Does not require reading a large amount of documentation.
+A new contributor should be able to clone the repository, start the site, and
+find the main content without learning the internals of Next.js. Fork-specific
+settings should be documented, searchable, and kept in as few places as
+practical.
 
-## Fast
+## Fast by default
 
-1. Follows [JAMStack best practices](https://jamstack.org/best-practices/). Everything that can be pre-rendered should be pre-rendered.
-1. Time to interact should be very fast (< 250 ms). Optimized for small bundle sizes.
+The production site is a static export, so routes must remain statically
+renderable. Keep client-side JavaScript and third-party code modest. Measure
+performance before adding complexity intended to improve it.
 
-## Good Developer Experience
+## Easy to change
 
-1. Modular
-   - It should be relatively straight forward to replace the content in this repository or to add a new feature.
-   - Good separation of concerns. Components keep track of their own state. Props are not over-utilized.
-   - Limited vertical depth (changes should be relatively self encapsulated).
-   - Correct abstractions. The Next.js build system is complex, but developers don't need to understand its internals to use this project.
-1. Good Documentation
-   - Comments exist and have an appropriate level of detail.
-   - Code should be readable.
-1. Lean
-   - Projects bloat over time. Actively prune for old and dead code.
-   - New features that affect the entire project should be carefully considered.
-   - Buy, don't build. Don't reinvent the wheel. Use popular npm libraries when possible. The exception is a dependency that would be larger than the problem: reading the dimensions out of an image header is a few dozen lines, and `src/lib/imageSize.ts` is deliberately cheaper than the library it replaces.
-1. Limited horizontal fragmentation
-   - Linter to prevent easy PR nits & to prevent developers from wasting time thinking about code style.
-   - Preferred React Style - functional components with TypeScript for type safety.
-   - Consistent file structure based on current best practices.
-   - Similar features are built similarly. Code reads like an assembly line, not a layer cake.
+- Keep components and data files focused.
+- Put similar features in similar places.
+- Prefer readable code over clever abstractions.
+- Automate formatting and routine checks.
+- Remove dead code and stale documentation.
+- Add a dependency when it is maintained and clearly cheaper than owning the
+  equivalent code.
 
-## Stable
+## Stable for forks
 
-1. Use _Boring_ technologies
-   - TypeScript for type safety while maintaining readability. Limited experimental features.
-   - Prefer popular and well maintained npm packages.
-1. Maintainable
-   - Easy setup.
-   - It should be easy to deploy any version of this site.
-   - Limited external dependencies (ie no missing headers for external libraries).
-   - Dependencies are kept up to date (currently uses dependabot).
-1. Good tests.
-1. Stable API - This project has been forked close to a thousand times. It should be easy for those forks to adopt changes in main.
+Prefer mature tools, explicit types, and repeatable builds. Test published
+content, metadata, accessibility-sensitive behavior, and static deployment.
+When a change affects fork configuration or public routes, document the
+migration.
 
-## Visual Design
+## Visual design
 
-The site's visual system is documented alongside the code it governs, in the
-design-system entries of [AGENTS.md](../AGENTS.md): three deliberate type roles,
-structure carried by hairlines rather than shadow and float, and an accent
-colour reserved for structure and links with a separate signal colour held back
-for values that are genuinely live.
+The visual system uses display type for headings, serif type for prose, and
+monospace type for labels and data. Hairlines and spacing establish structure.
+Ultramarine handles links, structure, and controls. Amber is reserved for live
+or in-progress values.
 
-The principles on this page are about how the code is organized; those entries
-are about how the site looks and why. Changing one rarely means changing the
-other.
+The implementation lives in [`app/styles/tokens/`](../app/styles/tokens/).
 
 ## References
 
-For further reading, please review
-
-- React's [Design Principles](https://legacy.reactjs.org/docs/design-principles.html).
-- [Thinking in React](https://react.dev/learn/thinking-in-react).
+- [Thinking in React](https://react.dev/learn/thinking-in-react)
+- [Rules of React](https://react.dev/reference/rules)

--- a/docs/design-goals.md
+++ b/docs/design-goals.md
@@ -1,6 +1,6 @@
 # Design Goals
 
-This projects attempts to follow these design principles. Feedback and discussion around these are encouraged. Please feel free to submit an issue or get in touch.
+This project attempts to follow these design principles. Feedback and discussion around these are encouraged. Please feel free to submit an issue or get in touch.
 
 ## Simple
 
@@ -18,14 +18,14 @@ This projects attempts to follow these design principles. Feedback and discussio
    - It should be relatively straight forward to replace the content in this repository or to add a new feature.
    - Good separation of concerns. Components keep track of their own state. Props are not over-utilized.
    - Limited vertical depth (changes should be relatively self encapsulated).
-   - Correct abstractions. - Next.js build system is complex, but developers don't need to understand the internals to use this project.
+   - Correct abstractions. The Next.js build system is complex, but developers don't need to understand its internals to use this project.
 1. Good Documentation
    - Comments exist and have an appropriate level of detail.
    - Code should be readable.
 1. Lean
    - Projects bloat over time. Actively prune for old and dead code.
    - New features that affect the entire project should be carefully considered.
-   - Buy, don't build. Don't reinvent the wheel. Use popular npm libraries when possible.
+   - Buy, don't build. Don't reinvent the wheel. Use popular npm libraries when possible. The exception is a dependency that would be larger than the problem: reading the dimensions out of an image header is a few dozen lines, and `src/lib/imageSize.ts` is deliberately cheaper than the library it replaces.
 1. Limited horizontal fragmentation
    - Linter to prevent easy PR nits & to prevent developers from wasting time thinking about code style.
    - Preferred React Style - functional components with TypeScript for type safety.
@@ -43,10 +43,23 @@ This projects attempts to follow these design principles. Feedback and discussio
    - Limited external dependencies (ie no missing headers for external libraries).
    - Dependencies are kept up to date (currently uses dependabot).
 1. Good tests.
-1. Stable API - This project has been forked > 100 times. It should be easy for those forks adopt changes in main.
+1. Stable API - This project has been forked close to a thousand times. It should be easy for those forks to adopt changes in main.
+
+## Visual Design
+
+The site's visual system is called "Ground Station." It is documented alongside
+the code it governs, in the design-system entries of [AGENTS.md](../AGENTS.md):
+three deliberate type roles, structure carried by hairlines rather than shadow
+and float, and an accent colour reserved for structure and links with a separate
+signal colour held back for values that are genuinely live.
+
+The principles on this page are about how the code is organized. Ground Station
+is about how the site looks and why. Changing one rarely means changing the
+other.
 
 ## References
 
 For further reading, please review
 
-- React's [Design Principles](https://react.dev/learn/thinking-in-react).
+- React's [Design Principles](https://legacy.reactjs.org/docs/design-principles.html).
+- [Thinking in React](https://react.dev/learn/thinking-in-react).

--- a/docs/design-goals.md
+++ b/docs/design-goals.md
@@ -47,14 +47,14 @@ This project attempts to follow these design principles. Feedback and discussion
 
 ## Visual Design
 
-The site's visual system is called "Ground Station." It is documented alongside
-the code it governs, in the design-system entries of [AGENTS.md](../AGENTS.md):
-three deliberate type roles, structure carried by hairlines rather than shadow
-and float, and an accent colour reserved for structure and links with a separate
-signal colour held back for values that are genuinely live.
+The site's visual system is documented alongside the code it governs, in the
+design-system entries of [AGENTS.md](../AGENTS.md): three deliberate type roles,
+structure carried by hairlines rather than shadow and float, and an accent
+colour reserved for structure and links with a separate signal colour held back
+for values that are genuinely live.
 
-The principles on this page are about how the code is organized. Ground Station
-is about how the site looks and why. Changing one rarely means changing the
+The principles on this page are about how the code is organized; those entries
+are about how the site looks and why. Changing one rarely means changing the
 other.
 
 ## References

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,8 +6,8 @@ This site has been a work in progress since 2014, evolving to reflect current be
 
 **Design**
 
-- "Ground Station" visual system: three deliberate type roles, structure carried
-  by hairlines rather than shadow, and a signal colour reserved for live values
+- Rebuilt the visual system: three deliberate type roles, structure carried by
+  hairlines rather than shadow, and a signal colour reserved for live values
   (see the design-system notes in [AGENTS.md](../AGENTS.md))
 - Self-hosted variable fonts via Fontsource, removing the Google Fonts build
   dependency while keeping metric-adjusted fallbacks

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,53 +1,19 @@
 # Roadmap
 
-This site has been a work in progress since 2014, evolving to reflect current best practices, guided by the [design goals](./design-goals.md).
+This page tracks work that has not shipped. Current features and setup are
+documented in the [README](../README.md). Items are not ordered or scheduled.
 
-## Recently Completed
+## Site quality
 
-**Design**
+- Evaluate [JSON Resume](https://jsonresume.org/) compatibility and document any
+  extensions needed by this site's data.
+- Add Playwright coverage for navigation, theme switching, and the static
+  export.
+- Audit against WCAG 2.2 AA and fix confirmed failures.
+- Measure Font Awesome's contribution to shipped JavaScript before deciding
+  whether to replace it.
 
-- Rebuilt the visual system: three deliberate type roles, structure carried by
-  hairlines rather than shadow, and a signal colour reserved for live values
-  (see the design-system notes in [AGENTS.md](../AGENTS.md))
-- Self-hosted variable fonts via Fontsource, removing the Google Fonts build
-  dependency while keeping metric-adjusted fallbacks
-- Print stylesheet, so the résumé prints in full regardless of the active filter
-- Generated Open Graph share card (`npm run og`), committed alongside the
-  metadata that binds it to its inputs
+## Releases
 
-**Features**
-
-- Writing/blog page with RSS feed (`/writing`, `/feed.xml`), including draft
-  isolation so unpublished posts never reach the export
-- Dark mode with system preference detection and manual toggle
-- Theme-aware portraits for light/dark modes
-- Modernized favicon with SVG source
-
-**Infrastructure**
-
-- Migrated from SCSS to Tailwind CSS v4
-- Migrated from Jest to Vitest; 459 tests at ~87% line coverage
-- Upgraded to Next.js 16 (App Router) and React 19
-- Migrated from ESLint to Biome
-- Replaced react-burger-menu with native slide menu
-- TypeScript strict mode throughout, now on the native TypeScript compiler
-- Node baseline moved to 26, dropping end-of-life Node 20
-- `verify-export`, which inspects the generated HTML and XML for draft leaks,
-  contradictory robots directives, duplicate IDs, broken internal links, and
-  incomplete share metadata
-- Google Analytics 4 via @next/third-parties
-- SEO: sitemap, Open Graph, structured metadata
-- Branch protection on `main`
-
-## Future Direction
-
-**Improvements**
-
-- Adopt [JSON Resume](https://jsonresume.org/) standard
-- Add Playwright for e2e testing
-- Optimize FontAwesome (consider custom icon library)
-- Improve accessibility (WCAG compliance)
-
-**Repository**
-
-- Automated releases with semantic versioning
+- Define what major, minor, and patch versions mean for this site and its forks.
+- Once that policy is settled, automate tags and release notes.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,11 +2,23 @@
 
 This site has been a work in progress since 2014, evolving to reflect current best practices, guided by the [design goals](./design-goals.md).
 
-## Recently Completed (2024-2026)
+## Recently Completed
+
+**Design**
+
+- "Ground Station" visual system: three deliberate type roles, structure carried
+  by hairlines rather than shadow, and a signal colour reserved for live values
+  (see the design-system notes in [AGENTS.md](../AGENTS.md))
+- Self-hosted variable fonts via Fontsource, removing the Google Fonts build
+  dependency while keeping metric-adjusted fallbacks
+- Print stylesheet, so the résumé prints in full regardless of the active filter
+- Generated Open Graph share card (`npm run og`), committed alongside the
+  metadata that binds it to its inputs
 
 **Features**
 
-- Writing/blog page with RSS feed (`/writing`, `/feed.xml`)
+- Writing/blog page with RSS feed (`/writing`, `/feed.xml`), including draft
+  isolation so unpublished posts never reach the export
 - Dark mode with system preference detection and manual toggle
 - Theme-aware portraits for light/dark modes
 - Modernized favicon with SVG source
@@ -14,13 +26,18 @@ This site has been a work in progress since 2014, evolving to reflect current be
 **Infrastructure**
 
 - Migrated from SCSS to Tailwind CSS v4
-- Migrated from Jest to Vitest with 76%+ test coverage (268 tests)
-- Upgraded to Next.js 16 (App Router, Turbopack) and React 19
+- Migrated from Jest to Vitest; 459 tests at ~87% line coverage
+- Upgraded to Next.js 16 (App Router) and React 19
 - Migrated from ESLint to Biome
 - Replaced react-burger-menu with native slide menu
-- TypeScript strict mode throughout
+- TypeScript strict mode throughout, now on the native TypeScript compiler
+- Node baseline moved to 26, dropping end-of-life Node 20
+- `verify-export`, which inspects the generated HTML and XML for draft leaks,
+  contradictory robots directives, duplicate IDs, broken internal links, and
+  incomplete share metadata
 - Google Analytics 4 via @next/third-parties
 - SEO: sitemap, Open Graph, structured metadata
+- Branch protection on `main`
 
 ## Future Direction
 
@@ -33,5 +50,4 @@ This site has been a work in progress since 2014, evolving to reflect current be
 
 **Repository**
 
-- Branch protection for main
 - Automated releases with semantic versioning


### PR DESCRIPTION
## What changed

- Reframed setup and customization around copyable coding-agent requests for a full rebrand, writing changes, feature removal, visual updates, deployment, social links, and analytics.
- Added safe defaults to every request: read `AGENTS.md`, use a topic branch, and leave commits, pushes, merges, account settings, secrets, and DNS changes for explicit authorization.
- Protected authorship during a rebrand by requiring an inventory of existing posts, external writing, résumé entries, and projects before the shared identity changes.
- Expanded the reference map to cover the actual identity surfaces, including logo initials, portrait alt text, external writing, RSS copy, repository statistics, the personal map, metadata, and generated assets.
- Corrected the writing guidance. Forks need at least one published Markdown post, frontmatter images use `imageAlt`, Markdown images use normal alt text, and hiding the navigation link does not remove the writing feature.
- Corrected GitHub Pages guidance. Workflows must be enabled in a fork, a root user site requires an `<owner>.github.io` repository, custom domains should be verified before attachment and DNS routing, custom workflow deployments ignore `public/CNAME`, and project subpaths still need a path audit.
- Simplified the README, contributing guide, adapting guide, roadmap, design goals, and `AGENTS.md`, keeping detailed commands and facts in one reference location where possible.

## Verified

- `npm run format`
- `npm run format:check`
- `npm run lint`
- `npm run type-check`
- `npm test` (459 tests)
- `npm run og:check`
- `npm run build`
- `npm run verify-export` (14 pages)
- Local Markdown paths and anchors resolve
- No em or en dashes or targeted AI-writing patterns in the rewritten public docs