### PR TITLE
fix(css): unify the mobile breakpoint so 736px is not both

### DIFF
--- a/app/styles/base/reset.css
+++ b/app/styles/base/reset.css
@@ -79,7 +79,7 @@
     }
   }
 
-  @media (max-width: 736px) {
+  @media (max-width: 735px) {
     body {
       font-size: var(--text-base);
       padding-top: var(--header-height-mobile);

--- a/app/styles/components/skill-bar.css
+++ b/app/styles/components/skill-bar.css
@@ -77,7 +77,7 @@
     margin-bottom: 1.5rem;
   }
 
-  @media (max-width: 736px) {
+  @media (max-width: 735px) {
     .skill-button-container {
       justify-content: center;
     }

--- a/app/styles/layout/header.css
+++ b/app/styles/layout/header.css
@@ -59,7 +59,7 @@
   box-sizing: border-box;
 }
 
-@media (max-width: 736px) {
+@media (max-width: 735px) {
   .site-header {
     height: var(--header-height-mobile);
     line-height: var(--header-height-mobile);

--- a/app/styles/layout/page.css
+++ b/app/styles/layout/page.css
@@ -13,7 +13,7 @@
   min-height: calc(100dvh - var(--header-height));
 }
 
-@media (max-width: 736px) {
+@media (max-width: 735px) {
   .page-container {
     min-height: calc(100dvh - var(--header-height-mobile));
   }

--- a/app/styles/pages/content.css
+++ b/app/styles/pages/content.css
@@ -432,7 +432,7 @@
   color: var(--color-accent);
 }
 
-@media (max-width: 736px) {
+@media (max-width: 735px) {
   .about-section-nav {
     top: var(--header-height-mobile);
     flex-wrap: nowrap;

--- a/app/styles/pages/resume.css
+++ b/app/styles/pages/resume.css
@@ -51,7 +51,7 @@
   margin: 0;
 }
 
-@media (max-width: 736px) {
+@media (max-width: 735px) {
   .resume-page .courses .course-list {
     grid-template-columns: 1fr;
   }
@@ -109,7 +109,7 @@
   border-bottom: var(--rule) solid var(--color-border);
 }
 
-@media (max-width: 736px) {
+@media (max-width: 735px) {
   .resume-nav {
     top: var(--header-height-mobile);
     gap: 0 1rem;

--- a/app/styles/pages/writing.css
+++ b/app/styles/pages/writing.css
@@ -228,7 +228,7 @@
   will-change: transform;
 }
 
-@media (max-width: 736px) {
+@media (max-width: 735px) {
   .reading-progress {
     top: var(--header-height-mobile);
   }
@@ -314,7 +314,7 @@
   scroll-margin-top: calc(var(--header-height) + var(--spacing-6));
 }
 
-@media (max-width: 736px) {
+@media (max-width: 735px) {
   .prose h2,
   .prose h3,
   .prose h4 {

--- a/app/styles/tokens/spacing.css
+++ b/app/styles/tokens/spacing.css
@@ -6,10 +6,9 @@
 @theme inline {
   /* ===================
      SPACING SCALE
-     Base unit: 4px (0.25rem)
+     Base unit: 4px (0.25rem). Curated rather than exhaustive — steps are
+     added when something needs them, not kept on the chance it might.
      =================== */
-  --spacing-1: 0.25rem; /* 4px */
-  --spacing-2: 0.5rem; /* 8px */
   --spacing-3: 0.75rem; /* 12px */
   --spacing-4: 1rem; /* 16px */
   --spacing-5: 1.25rem; /* 20px */


### PR DESCRIPTION
## The bug

`max-width: 736px` and `min-width: 736px` are **both true at exactly 736px**, and the stylesheets used both for the same nominal cutover.

At that width the desktop navigation was rendering inside a mobile-height header:

| File | Query | Effect at exactly 736px |
|---|---|---|
| `navigation.css:34` | `min-width: 736px` | desktop nav row shows |
| `header.css:62` | `max-width: 736px` | header still uses `--header-height-mobile` |

The same 1px overlap existed between `page.css`'s container and main rules (`:16` vs `:37`) and between `content.css`'s about-section nav and its compact variant (`:435` vs `:457`).

**736px is not a contrived width — it is iPhone Plus landscape**, so this was reachable on a real device.

## The fix

The codebase already declared the right convention in two places: `header.css:142` (hamburger) and `footer.css:28` both use `max-width: 735px`, which pairs cleanly with `min-width: 736px`. This applies that same convention to the other ten `max-width` queries.

The rule is now uniform: **mobile is ≤735, desktop is ≥736, and no viewport matches both.**

I picked that direction rather than pushing `min-width` to 737 because the navigation already switches at 736 and two files already use 735 — so 735/736 is the convention the code was reaching for.

## Also

Dropped `--spacing-1` and `--spacing-2`, which nothing referenced (no `var()` use, no Tailwind `p-1`/`gap-1`-style utilities anywhere). The scale is curated rather than exhaustive and already skips most steps.

## Verification

Built before and after and diffed the emitted stylesheet:

```
18 changed lines = 9 media queries retargeted
differences that are NOT a 736->735 breakpoint change:
  (none)
```

**Every single change in the built CSS is a breakpoint boundary.** No rule body, no declaration, and not one byte of output from the removed tokens — the emitted CSS is the same 74,768 bytes, which is itself the proof those tokens were dead.

Full gate: lint, format, type-check, 450 tests, build, `verify-export`.

## Reviewed and deliberately not changed

- **`.skill-tag--md`** sets `font-weight: normal`, which `.skill-tag` already sets — a genuine no-op. But deleting it makes `SkillTag.tsx`'s ternary awkward and removes the legible middle tier from a deliberate lg/md/sm set, for zero behavioural gain. Three lines is not worth making the code less readable.
- **A repeated "mono label" recipe** (mono font + uppercase + muted colour + tracking) appears across ~20 rules, most notably duplicating the "section eyebrow with heavy top rule" between `cards.css:28` and `resume.css:31`. Consolidating it means adding a class token to ~15 components — a refactor with real visual risk, not a cleanup, and I have no browser here to verify it.
- **`writing.css:254`** uses `--tracking-label` where its sibling `:103` uses `--tracking-wide` for the same tabular date pattern. Cosmetic inconsistency; changing it alters rendering, so it is a design call.

Independent of #930 — no file overlap.