### PR TITLE
fix(resume): drop a misleading lastModified and correct a false comment

### DIFF
--- a/src/lib/__tests__/resumeJson.test.ts
+++ b/src/lib/__tests__/resumeJson.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import contact from '@/data/contact';
 import profile from '@/data/profile.json';
@@ -39,6 +39,29 @@ const ISO8601 =
   /^([1-2][0-9]{3}-[0-1][0-9]-[0-3][0-9]|[1-2][0-9]{3}-[0-1][0-9]|[1-2][0-9]{3})$/;
 
 const resume = buildJsonResume();
+
+/**
+ * Every inline `<a href>` in the source résumé prose. The doc comment on
+ * `toPlainText` claims the text of each one survives into the artifact and the
+ * href does not; these are what hold it to that.
+ */
+const sourceAnchors = work
+  .flatMap((position) => [
+    position.summary ?? '',
+    ...(position.highlights ?? []),
+  ])
+  .flatMap((source) => [
+    ...source.matchAll(/<a\s[^>]*href='([^']+)'[^>]*>([^<]+)<\/a>/g),
+  ])
+  .map((match) => ({ href: match[1], text: match[2] }));
+
+/** The plain-text prose of the built document, as one string. */
+const resumeProse = resume.work
+  .flatMap((position) => [
+    position.summary ?? '',
+    ...(position.highlights ?? []),
+  ])
+  .join('\n');
 
 describe('toPlainText', () => {
   it('keeps anchor text and drops the markup', () => {
@@ -147,6 +170,29 @@ describe('json resume document', () => {
     );
   });
 
+  it('keeps the text of every inline anchor', () => {
+    // Six, in three summaries — the count the `toPlainText` comment states.
+    expect(sourceAnchors).toHaveLength(6);
+
+    for (const { text } of sourceAnchors) {
+      expect(resumeProse).toContain(text);
+    }
+  });
+
+  it('drops every inline href, and no other field brings one back', () => {
+    const serialized = serializeJsonResume();
+    const entryUrls = new Set(work.map((position) => position.url));
+
+    for (const { href } of sourceAnchors) {
+      expect(serialized).not.toContain(href);
+      // These are third-party links — an announcement, three investors, two
+      // funds — not the employer's own `url`, so that field does not recover
+      // them. This is the assertion that refutes the comment this file used to
+      // carry.
+      expect(entryUrls.has(href)).toBe(false);
+    }
+  });
+
   it('leaves no markup or uncollapsed whitespace anywhere in the prose', () => {
     const prose = resume.work.flatMap((position) => [
       position.summary ?? '',
@@ -219,13 +265,34 @@ describe('json resume document', () => {
     }
   });
 
-  it('keeps the canonical file-like and the timestamp off the build clock', () => {
+  it('keeps the canonical file-like', () => {
     expect(RESUME_JSON_PATH).toBe('/resume.json');
     expect(RESUME_JSON_URL).toBe(`${SITE_URL}/resume.json`);
     expect(resume.meta.canonical).toBe(RESUME_JSON_URL);
     expect(resume.meta.canonical).not.toMatch(/resume\.json\/$/);
-    // The newest dated event in the work history, not "now".
-    expect(resume.meta.lastModified).toBe('2026-03-09T00:00:00Z');
+  });
+
+  it('publishes no lastModified rather than one that only means the work history', () => {
+    // It used to be the newest date in `work.ts`, which does not move when
+    // profile, contact, degrees, courses, or every skill changes.
+    expect(resume.meta).toEqual({ canonical: RESUME_JSON_URL });
+    expect(serializeJsonResume()).not.toContain('lastModified');
+  });
+
+  it('reads nothing from the build clock', () => {
+    // Stronger than asserting one field is not `Date.now()`: the whole
+    // document has to come out byte-identical after the clock moves years, so
+    // a rebuild cannot churn the artifact in git.
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+      const first = serializeJsonResume();
+      vi.setSystemTime(new Date('2031-06-30T12:34:56Z'));
+
+      expect(serializeJsonResume()).toBe(first);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('serializes to stable, pretty-printed bytes', () => {

--- a/src/lib/resumeJson.ts
+++ b/src/lib/resumeJson.ts
@@ -97,7 +97,6 @@ export interface JsonResume {
   skills: ResumeSkill[];
   meta: {
     canonical: string;
-    lastModified: string;
   };
 }
 
@@ -128,8 +127,16 @@ function decodeEntity(entity: string): string {
  * HTML — `JobSummary` renders them through `markdown-to-jsx`, and three of them
  * carry real `<a href>` anchors. The rendered page depends on that markup, so
  * this strips it for the artifact rather than flattening the source data and
- * costing the page its links. The URLs are not lost: every employer's own
- * `url` is already a field on the work entry.
+ * costing the page its links.
+ *
+ * The anchor text survives and the href does not, and nothing else in the
+ * document recovers it. All six are third-party links — the Codex Security
+ * announcement, Anthemis, Foundation Capital, Y Combinator, NEA, Accel — not
+ * the employer's own `url`, which is a separate field on the work entry and
+ * points somewhere else. That is the accepted cost: JSON Resume prose is plain
+ * text, and the schema has nowhere to hang a link inside a summary. The test
+ * file pins both halves, so this paragraph fails rather than rots when a
+ * summary changes.
  *
  * Underscore emphasis is intentionally left alone: `_x_` would eat the
  * underscores out of an identifier like `snake_case_name`.
@@ -259,21 +266,26 @@ function buildSkills(): ResumeSkill[] {
 }
 
 /**
- * The most recent dated event in the work history — not the build clock. The
- * same discipline as `feed.xml`'s `lastBuildDate`: a timestamp read from the
- * clock would rewrite the artifact on every rebuild and could not be pinned by
- * a test.
+ * Assembles the document. `meta.lastModified` is deliberately absent.
+ *
+ * It was emitted as the newest `startDate`/`endDate` in
+ * `src/data/resume/work.ts`, which is a date about the work history rather than
+ * about the document. Editing `profile.json`, `contact.ts`, `degrees.ts`,
+ * `courses.ts`, or every skill in `skills.ts` left it untouched — the one field
+ * that named itself "last modified" was the field least able to notice a
+ * modification.
+ *
+ * Nothing in the data replaces it honestly. Only `work` and `degrees` carry
+ * dates at all, and the newest across both is the same work-history date the
+ * old implementation already published, so widening the search would broaden
+ * the claim without broadening what it can actually see. The build clock is not
+ * an option either: a timestamp read from the clock rewrites the artifact on
+ * every rebuild, churns it in git, and cannot be pinned by a test — the same
+ * discipline `feed.xml` applies to `lastBuildDate`. `meta.lastModified` is
+ * optional in JSON Resume, so the field is omitted rather than published
+ * meaning something narrower than its name. `work[0].startDate` already states
+ * the recency of the work history, under a name that is true.
  */
-function lastModified(): string {
-  const dates = work.flatMap((position) =>
-    [position.startDate, position.endDate].filter(
-      (date): date is string => !!date,
-    ),
-  );
-  // ISO dates sort lexicographically.
-  return `${dates.sort().at(-1)}T00:00:00Z`;
-}
-
 export function buildJsonResume(): JsonResume {
   return {
     $schema: RESUME_SCHEMA_URL,
@@ -283,7 +295,6 @@ export function buildJsonResume(): JsonResume {
     skills: buildSkills(),
     meta: {
       canonical: RESUME_JSON_URL,
-      lastModified: lastModified(),
     },
   };
 }


### PR DESCRIPTION
Two low-severity defects in `src/lib/resumeJson.ts`, both confirmed on inspection.

## 1. `meta.lastModified` meant something narrower than its name

`lastModified()` collected only `startDate`/`endDate` from `src/data/resume/work.ts` and emitted the maximum. So the field that named itself "last modified" was the field least able to notice a modification: editing `profile.json` (name, role, email, city), `contact.ts` (all six profile URLs), `degrees.ts`, `courses.ts`, or every entry in `skills.ts` left the timestamp untouched.

**The choice, and why.** The field is dropped rather than widened.

The alternative offered was to derive it from the newest date across all dated data files. I checked what that actually yields: `courses.ts`, `skills.ts`, and `contact.ts` carry no dates at all, `degrees.ts` carries years (2016, 2012), and `profile.json` carries a birth date. The maximum across every dated file is therefore *the same work-history date the old implementation already published*. Widening the search would broaden the claim without broadening what the claim can see — a wider lie for identical output. It also would not have fixed the reported symptom: edit every skill, and the timestamp still does not move.

Reading the clock is out: it rewrites the artifact on every rebuild, churns it in git, defeats caching, and cannot be pinned by a test — the discipline `feed.xml` already applies to `lastBuildDate`. Reading git or file mtimes is out too: `actions/checkout` clones at depth 1, so `git log -1 -- src/data` returns nothing on most builds, and a fresh clone's mtimes are the checkout time, i.e. the build clock wearing a hat. Hand-maintaining a date in a data file is the failure mode AGENTS.md already names — a figure typed by hand with nothing checking it.

`meta.lastModified` is optional in JSON Resume, so no field ships. `work[0].startDate` already states the recency of the work history under a name that is true, and `meta.canonical` is unchanged. `scripts/verify-export.mjs` checks the root key set and `meta.canonical`, neither of which is affected.

## 2. The `toPlainText` doc comment was false

It claimed stripping inline anchors cost nothing because "every employer's own `url` is already a field on the work entry." It is not. The six hrefs are third-party:

| href | entry `url` |
| --- | --- |
| `openai.com/index/codex-security-now-in-research-preview/` | `https://openai.com` |
| `anthemis.com`, `foundationcapital.com`, `ycombinator.com` | `https://arthena.com` |
| `nea.com`, `accel.com` | `https://matroid.com` |

None appears anywhere in the artifact. The **behaviour** is correct — JSON Resume prose is plain text, and the schema has nowhere to hang a link inside a summary — so nothing about the output changes. Only the justification is rewritten, to say what is true: the anchor text is preserved, the href is dropped, and these particular URLs do not survive.

**On preserving them:** I judge none worth keeping. Doing so would need an invented `meta` key or a fake `projects`/`references` entry, and the one thing that actually fails JSON Resume validation is a non-schema property. The Codex Security announcement is the only one a reader might want, and it is reachable in one click from `https://openai.com`, which the entry already carries.

## Tests

The removed `lastModified` assertion is replaced by the property it existed to protect, generalized rather than deleted: `serializeJsonResume()` must return byte-identical output after `vi.setSystemTime` moves the clock five years. That covers any future field, not just the one that was there.

Two new tests convert the corrected comment into an enforced property, by extracting every `<a href>` from the source prose and asserting that (a) each anchor's text reaches the built prose, (b) no anchor's href appears anywhere in the serialized document, and (c) no anchor's href equals any entry's `url` — the assertion that directly refutes the sentence this PR removes. If a summary gains or loses an anchor, the count assertion fails and the next author has to re-read the comment.

## Verification

```
npm run format
npx biome check .   # exit 0
npx tsc --noEmit    # exit 0
npx vitest run      # 80 files, 797 passed (793 on base, +4 here)
```

Files touched: `src/lib/resumeJson.ts`, `src/lib/__tests__/resumeJson.test.ts`. `buildWork()`'s `sortPositions` change is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)