### PR TITLE
test(about): make the model-number guard actually able to fail

### DIFF
--- a/src/lib/__tests__/logEntry.test.ts
+++ b/src/lib/__tests__/logEntry.test.ts
@@ -146,13 +146,34 @@ describe('extractLogMarker', () => {
     }
   });
 
-  it('does not read a model number as a year', () => {
+  it('does not read a number that is not a date as a year', () => {
+    // Every string here contains a run of digits that `YEAR_PATTERN` matches on
+    // its own, which is what makes this test able to fail: relax any part of
+    // the inline year guard — the preposition anchor, either word boundary, or
+    // the 18xx/19xx/20xx shape — and one of these arrives in the gutter as a
+    // date. The prose the guard was written for cannot do that. "Mavica
+    // MVC-FD71", "Nikon D750", "Pentium III", "approximately 50 countries" hold
+    // no four-digit run at all, so a test built from them passes against a
+    // guard that has been deleted.
+    for (const text of [
+      // An unprefixed model number: nothing here says this 2000 is a date.
+      'It was an old Tandy 2000 that ran MS-DOS.',
+      // "Garmin" ends in "in", which is a preposition only across a boundary.
+      'I still navigate with a Garmin 2000 on the bike.',
+      // A decade is not a year, and "1990s" is not "1990".
+      'I kept a box of 1990s computer magazines.',
+      // Four digits that are a quantity rather than a year-shaped number.
+      'The whole shoot fit on a floppy of 1440 KB.',
+    ]) {
+      expect(extractLogMarker(text), text).toBeNull();
+    }
+
+    // The same number, prefixed, is a date: the anchor separates the two, and
+    // has not simply turned the guard into a refusal to read anything.
     expect(
-      extractLogMarker('My camera is a Sony Mavica MVC-FD71, and it works.'),
-    ).toBeNull();
-    expect(
-      extractLogMarker('I shoot with a Nikon D750 and a D800 these days.'),
-    ).toBeNull();
+      extractLogMarker('I retired that Tandy in 2000, after seven years.')
+        ?.year,
+    ).toBe('2000');
   });
 
   it('omits the age for a year that predates the birth year', () => {


### PR DESCRIPTION
## The finding, verified

`INLINE_YEAR` in `src/lib/logEntry.ts` anchors its year match to a preposition:

```ts
const INLINE_YEAR = new RegExp(
  `\\b(?:in|of|since|during|by)\\s+(${YEAR_PATTERN.source})\\b`,
  'i',
);
```

The comment above it says the anchor exists "so that a stray number —
'approximately 50 countries', 'a Sony Mavica MVC-FD71' — is not read as a date."
The test that existed for it was:

```ts
it('does not read a model number as a year', () => {
  expect(extractLogMarker('My camera is a Sony Mavica MVC-FD71, and it works.')).toBeNull();
  expect(extractLogMarker('I shoot with a Nikon D750 and a D800 these days.')).toBeNull();
});
```

Neither string contains a four-digit run, so `YEAR_PATTERN`
(`(?:1[89]|20)\d{2}`) cannot match either of them with or without the anchor.
The test asserted `null` against an implementation that had no way to return
anything else.

**Mutation result, before this change** — with the entire
`(?:in|of|since|during|by)\s+` anchor deleted from `INLINE_YEAR`:

```
Test Files  80 passed (80)
     Tests  793 passed (793)
```

The whole suite, not just this file. The guard was load-bearing and unprotected.

## What this changes

Only `src/lib/__tests__/logEntry.test.ts`. `logEntry.ts` is untouched — the
implementation is correct; the test was not.

The replacement feeds the function strings that **do** contain a run
`YEAR_PATTERN` matches, which is the whole point: that is what gives the
assertion the ability to fail. Four adjacent guards are covered instead of one.

| Case | Guard it exercises |
| --- | --- |
| `It was an old Tandy 2000 that ran MS-DOS.` | the `(?:in\|of\|since\|during\|by)\s+` anchor |
| `I still navigate with a Garmin 2000 on the bike.` | the **leading** `\b` — "Garm**in** 2000" is a preposition only across a word boundary |
| `I kept a box of 1990s computer magazines.` | the **trailing** `\b` — a decade is not a year, and "1990s" is not "1990" |
| `The whole shoot fit on a floppy of 1440 KB.` | `YEAR_PATTERN`'s 18xx/19xx/20xx shape, not merely "four digits" |

Plus one positive case, so the guard is pinned as a discriminator rather than a
blanket refusal: `I retired that Tandy in 2000, after seven years.` still reads
`2000`.

**Mutation result, after this change** — each relaxation applied on its own:

| Mutation | Old test | New test |
| --- | --- | --- |
| preposition anchor removed | SURVIVED | **KILLED** |
| `YEAR_PATTERN` → `\d{4}` | SURVIVED | **KILLED** |
| trailing `\b` removed | SURVIVED | **KILLED** |
| leading `\b` removed | SURVIVED | **KILLED** |

With the anchor removed the new test fails
(`× does not read a number that is not a date as a year`, 1 failed / 17 passed);
with it restored, 18 passed. That contrast is the deliverable.

## The rest of the file

I mutation-tested every other guard in `logEntry.ts` against the existing
assertions. The remaining four were already properly covered and needed no
change: the `INLINE_AGE` anchor (killed by "approximately 50 countries" — that
half of the source comment *is* a valid example), `openingSentence`, the
negative-age guard, and the empty-remainder guard. All eight mutants are now
killed.

## One correction to the record

The source comment on `INLINE_YEAR`, and the matching line in `AGENTS.md`, both
cite "a Sony Mavica MVC-FD71" as prose the year anchor protects against. It is
not — there is no four-digit run in it, and `INLINE_YEAR` was never in play.
"approximately 50 countries" is a correct example, but of the *`INLINE_AGE`*
anchor. Citing an example the guard cannot see is what produced a test that
could not fail. I left both files alone to stay inside my scope; the new test
carries the accurate explanation.

Related: `src/data/about.ts` contains no four-digit non-year number anywhere in
the two log sections today, so the guard is entirely prospective. Its test cases
therefore have to be constructed rather than quoted — and that is precisely why
it needs a test at all.

## Verification

```
npm run format     # no diff beyond the test file
npx biome check .  # Checked 221 files. No fixes applied.
npx tsc --noEmit   # clean
npx vitest run     # 80 files, 793 passed
```

The 793 count is unchanged because this rewrites a test in place rather than
adding one; the change is in what that test can detect, not how many there are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
