### PR TITLE
fix(scripts): scope the draft-asset scan and align the draft predicate

### DIFF
--- a/public/og.meta.json
+++ b/public/og.meta.json
@@ -19,7 +19,7 @@
     "accent": "#1b2fbf",
     "hairline": "rgba(35, 39, 46, 0.14)"
   },
-  "generatorDigest": "ebbff8ac512f1c8f6e12781948f9aec362406b2db2c90fae0df418b288e189e9",
+  "generatorDigest": "9604f78154b475e806c714c5750130ca212eab90f038002c9471c357fd0b4bbd",
   "imageDigest": "9c76fd6b9be9ed5e8253a35ee7b741e219b2bfd5484b5bd29c90eb7a3241d4eb",
   "posts": [
     {

--- a/scripts/__tests__/drafts.test.ts
+++ b/scripts/__tests__/drafts.test.ts
@@ -1,0 +1,184 @@
+/**
+ * The one rule three readers have to agree on.
+ *
+ * `isPublished` in `src/lib/posts.ts` decides what the site renders, and a plain
+ * Node build script cannot import it, so `scripts/og-inputs.mjs` reimplements
+ * the rule and `scripts/verify-export.mjs` imports that reimplementation. This
+ * file is what holds them together.
+ *
+ * They disagreed. Both scripts skipped a post only when `draft === true`, while
+ * `validatePostFrontmatter` throws for any `draft` that is not a boolean — so a
+ * quoted `draft: 'true'`, a plausible typo, failed the site build outright while
+ * `npm run og:check` told the author to commit a share card for it. The fix is
+ * not to copy the app's validator into a script; it is to make the scripts
+ * refuse anything that is not an explicit, unambiguous "published", so a
+ * malformed flag can never produce a published artifact.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import matter from 'gray-matter';
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { validatePostFrontmatter } from '@/lib/posts';
+import { isDraftFrontmatter, readPostCards } from '../og-inputs.mjs';
+
+interface DraftCase {
+  /** The frontmatter as an author would write it. */
+  name: string;
+  slug: string;
+  /** The `draft` line, or null for frontmatter that omits the key entirely. */
+  line: string | null;
+  /** What every reader must conclude. */
+  isDraft: boolean;
+  /** Whether `validatePostFrontmatter` refuses the value outright. */
+  appRefuses: boolean;
+}
+
+const CASES: DraftCase[] = [
+  {
+    name: 'draft: true',
+    slug: 'boolean-true',
+    line: 'draft: true',
+    isDraft: true,
+    appRefuses: false,
+  },
+  {
+    name: 'draft: false',
+    slug: 'boolean-false',
+    line: 'draft: false',
+    isDraft: false,
+    appRefuses: false,
+  },
+  {
+    name: "draft: 'true'",
+    slug: 'quoted-true',
+    line: "draft: 'true'",
+    isDraft: true,
+    appRefuses: true,
+  },
+  // The interesting one. A quoted `false` reads as "published" to a human and
+  // is refused by the site, so the scripts must withhold rather than guess.
+  {
+    name: "draft: 'false'",
+    slug: 'quoted-false',
+    line: "draft: 'false'",
+    isDraft: true,
+    appRefuses: true,
+  },
+  {
+    name: 'no draft key',
+    slug: 'no-key',
+    line: null,
+    isDraft: false,
+    appRefuses: false,
+  },
+  {
+    name: 'draft: 1',
+    slug: 'numeric',
+    line: 'draft: 1',
+    isDraft: true,
+    appRefuses: true,
+  },
+];
+
+/**
+ * Matches how the real posts are written: the date is quoted, because YAML
+ * parses a bare `2026-01-08` into a `Date` and both readers want the string.
+ */
+function postSource(entry: DraftCase) {
+  return [
+    '---',
+    `title: Post ${entry.slug}`,
+    "date: '2026-01-08'",
+    `description: Frontmatter fixture for ${entry.slug}.`,
+    ...(entry.line === null ? [] : [entry.line]),
+    '---',
+    '',
+    'Body prose so the card readout has something to measure.',
+    '',
+  ].join('\n');
+}
+
+function frontmatterOf(entry: DraftCase) {
+  return matter(postSource(entry)).data;
+}
+
+const fixtureRoots: string[] = [];
+
+function createFixture() {
+  const root = mkdtempSync(join(tmpdir(), 'draft-predicate-'));
+  fixtureRoots.push(root);
+  mkdirSync(join(root, 'content', 'writing'), { recursive: true });
+
+  for (const entry of CASES) {
+    writeFileSync(
+      join(root, 'content', 'writing', `${entry.slug}.md`),
+      postSource(entry),
+    );
+  }
+
+  return root;
+}
+
+afterAll(() => {
+  for (const root of fixtureRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('the draft predicate the build scripts share', () => {
+  it.each(CASES)('reads $name as draft: $isDraft', (entry) => {
+    expect(isDraftFrontmatter(frontmatterOf(entry))).toBe(entry.isDraft);
+  });
+
+  it('treats frontmatter with no draft key at all as published', () => {
+    expect(isDraftFrontmatter({})).toBe(false);
+  });
+
+  /**
+   * `draft:` with nothing after it parses as null, which is neither a boolean
+   * the site accepts nor an absent key, so it is withheld like any other
+   * malformed value.
+   */
+  it('withholds an empty draft value', () => {
+    expect(isDraftFrontmatter(matter('---\ndraft:\n---\n').data)).toBe(true);
+  });
+
+  it.each(CASES)(
+    'never publishes what the site refuses to build: $name',
+    (entry) => {
+      const data = frontmatterOf(entry);
+      const source = `content/writing/${entry.slug}.md`;
+
+      if (entry.appRefuses) {
+        expect(() => validatePostFrontmatter(data, source)).toThrow(
+          '"draft" must be a boolean when provided',
+        );
+        // The site will not build this file. The scripts must therefore not
+        // produce an artifact for it either — declining is the safe side of a
+        // disagreement, publishing is not.
+        expect(isDraftFrontmatter(data)).toBe(true);
+        return;
+      }
+
+      // Where the site accepts the value, the two readers must land on exactly
+      // the same answer: `isPublished` is `!post.draft` outside `next dev`.
+      const frontmatter = validatePostFrontmatter(data, source);
+      expect(Boolean(frontmatter.draft)).toBe(isDraftFrontmatter(data));
+    },
+  );
+});
+
+describe('readPostCards', () => {
+  it('generates a card only for the unambiguously published cases', async () => {
+    const cards = (await readPostCards(createFixture())) as { slug: string }[];
+
+    expect(cards.map((card) => card.slug).sort()).toEqual(
+      CASES.filter((entry) => !entry.isDraft)
+        .map((entry) => entry.slug)
+        .sort(),
+    );
+  });
+});

--- a/scripts/__tests__/verify-export.test.ts
+++ b/scripts/__tests__/verify-export.test.ts
@@ -369,14 +369,34 @@ describe('verify-export', () => {
     );
   });
 
-  it('rejects any other export named after a draft', () => {
+  /**
+   * A leaked draft route ships more than its HTML: Next writes an RSC prefetch
+   * payload beside every prerendered route, and nothing else here reads it.
+   */
+  it('rejects a non-HTML file beside a draft route', () => {
     const root = createFixture();
-    write(root, 'out/downloads/secret-draft/notes.pdf');
+    write(root, 'out/writing/secret-draft/index.txt');
 
     const result = runVerifier(root);
     expect(result.status).toBe(1);
     expect(result.output).toContain(
-      'exports an asset named after a draft post: /downloads/secret-draft/notes.pdf',
+      'exports an asset named after a draft post: /writing/secret-draft/index.txt',
+    );
+  });
+
+  /**
+   * Article images live one directory per post under `public/images/writing/`,
+   * and `public/` ships verbatim, so that directory is a real place for a
+   * draft's screenshots to become publicly fetchable.
+   */
+  it('rejects an article image directory named after a draft', () => {
+    const root = createFixture();
+    write(root, 'out/images/writing/secret-draft/screenshot.webp');
+
+    const result = runVerifier(root);
+    expect(result.status).toBe(1);
+    expect(result.output).toContain(
+      'exports an asset named after a draft post: /images/writing/secret-draft/screenshot.webp',
     );
   });
 
@@ -389,6 +409,53 @@ describe('verify-export', () => {
     // Page count tracks `createFixture`, which carries index, about, and
     // resume. A published post's card is not a page and must not change it.
     expect(result.output).toContain('3 pages OK');
+  });
+
+  /**
+   * The gate is about files generated from `content/writing/`, not about names.
+   * Matching a draft slug against any path segment anywhere in `out/` meant a
+   * draft called `photo` or `resume` failed the whole build over
+   * `images/photo.png` and `resume.json` — committed files nothing derived from
+   * a post, reported as a draft leak.
+   */
+  it('accepts committed assets whose names collide with a draft slug', () => {
+    const root = createFixture();
+    write(
+      root,
+      'content/writing/photo.md',
+      '---\ntitle: Photo\ndraft: true\n---\n',
+    );
+    write(
+      root,
+      'content/writing/resume.md',
+      '---\ntitle: Resume\ndraft: true\n---\n',
+    );
+
+    const result = runVerifier(root);
+    expect(result.status).toBe(0);
+    expect(result.output).toContain('3 pages OK');
+  });
+
+  /**
+   * The gate and the card generator have to agree on what a draft is.
+   * `validatePostFrontmatter` throws for a non-boolean `draft`, so a quoted
+   * `draft: 'true'` never builds — but both scripts once read it as published,
+   * which is how a card for it got committed with nothing objecting.
+   */
+  it('rejects a card for a post whose draft flag is malformed', () => {
+    const root = createFixture();
+    write(
+      root,
+      'content/writing/quoted-draft.md',
+      "---\ntitle: Quoted draft\ndraft: 'true'\n---\n",
+    );
+    write(root, 'out/og/writing/quoted-draft.png');
+
+    const result = runVerifier(root);
+    expect(result.status).toBe(1);
+    expect(result.output).toContain(
+      'exports an asset named after a draft post: /og/writing/quoted-draft.png',
+    );
   });
 
   it('rejects an export with no machine-readable resume', () => {

--- a/scripts/og-inputs.mjs
+++ b/scripts/og-inputs.mjs
@@ -207,6 +207,30 @@ export function measurePost(markdown) {
 }
 
 /**
+ * Whether frontmatter marks a post as unpublished.
+ *
+ * A plain Node script cannot import `isPublished` from `src/lib/posts.ts`, so
+ * the rule is necessarily reimplemented — and the two have to agree on the safe
+ * side rather than merely overlap. `validatePostFrontmatter` throws for any
+ * `draft` that is not a boolean, so a quoted `draft: 'true'` fails the site
+ * build outright; a script testing `draft === true` called that same post
+ * published and told the author to commit a share card carrying its title.
+ *
+ * Only an explicit, unambiguous "not a draft" publishes here: the key absent,
+ * or literally `false`. Every other value is withheld, so a malformed flag can
+ * never produce a published artifact — the script declines where the app
+ * throws. `scripts/__tests__/drafts.test.ts` enumerates the cases and pins this
+ * against the TypeScript reader.
+ *
+ * `verify-export.mjs` imports this rather than repeating it, because a third
+ * copy of the rule is a third thing to drift.
+ */
+export function isDraftFrontmatter(data) {
+  const draft = data?.draft;
+  return draft !== undefined && draft !== false;
+}
+
+/**
  * The published posts that get a card, newest first.
  *
  * Drafts are excluded unconditionally. `public/` is copied verbatim into the
@@ -228,7 +252,7 @@ export async function readPostCards(root = process.cwd()) {
       await readFile(join(directory, file), 'utf8'),
     );
 
-    if (data.draft === true) continue;
+    if (isDraftFrontmatter(data)) continue;
 
     const slug = file.replace(/\.md$/, '');
     assertSafeSlug(slug, join(CONTENT_DIRECTORY, file));

--- a/scripts/verify-export.mjs
+++ b/scripts/verify-export.mjs
@@ -21,6 +21,7 @@ import {
   tags,
 } from './lib/html.mjs';
 import { exportLayout, readSiteConfig, toUrlPath } from './lib/site.mjs';
+import { isDraftFrontmatter, POST_CARD_DIRECTORY } from './og-inputs.mjs';
 
 const ROOT = process.cwd();
 const OUT = resolve(ROOT, 'out');
@@ -67,8 +68,11 @@ if (pages.length === 0) {
 const draftSlugs = walk(CONTENT, (name) => name.endsWith('.md'))
   // Use the same YAML parser as the application. A line regex misses valid
   // forms such as `draft: true # keep private`, weakening the fault-injection
-  // gate precisely when the route layer regresses.
-  .filter((path) => matter(readFileSync(path, 'utf8')).data.draft === true)
+  // gate precisely when the route layer regresses. `isDraftFrontmatter` is the
+  // share-card scripts' predicate, imported rather than repeated: a gate that
+  // disagreed with the generator about what a draft is would wave through the
+  // exact artifact the generator should never have produced.
+  .filter((path) => isDraftFrontmatter(matter(readFileSync(path, 'utf8')).data))
   .map((path) => basename(path, '.md'));
 
 function isDraftPath(pathname) {
@@ -80,7 +84,45 @@ function isDraftPath(pathname) {
 }
 
 /**
- * Nothing in the export may be named after a draft, not only routes.
+ * Where in the export a file belonging to one post can appear.
+ *
+ * `POST_CARD_DIRECTORY` is the generated share cards, taken from the generator's
+ * own constant so moving them cannot silently un-scope this gate. `/writing` is
+ * the posts' own route tree, which carries more than HTML: Next writes an RSC
+ * prefetch payload beside every prerendered route, so a leaked draft route also
+ * ships an `index.txt` that no metadata check reads. `/images/writing` is where
+ * article images live, one directory per post.
+ *
+ * A new per-post asset directory has to be registered here, or it ships
+ * unwatched — that is the cost of scoping, and it is the smaller cost. The scan
+ * used to match any path segment anywhere in `out/`, which meant a draft slug
+ * colliding with an unrelated committed file (`notes.md` against
+ * `public/images/notes.png`) failed the whole build with a draft-leak message
+ * pointing at a file nothing generated.
+ */
+const POST_ASSET_ROOTS = [POST_CARD_DIRECTORY, '/writing', '/images/writing'];
+
+/**
+ * A route under one of those directories that belongs to a draft.
+ *
+ * The slug has to be a whole path component: `<root>/<slug>` itself, anything
+ * beneath it, or a sibling file named for it (`<root>/<slug>.png`). A prefix
+ * match alone would also catch `<root>/<slug>-part-two.png`, which is a
+ * different post.
+ */
+function isDraftAsset(route) {
+  return POST_ASSET_ROOTS.some((root) =>
+    draftSlugs.some(
+      (slug) =>
+        route === `${root}/${slug}` ||
+        route.startsWith(`${root}/${slug}/`) ||
+        route.startsWith(`${root}/${slug}.`),
+    ),
+  );
+}
+
+/**
+ * Nothing generated from a draft may reach the export, not only routes.
  *
  * The route and metadata checks below see HTML and XML. `public/` is copied
  * into the export verbatim, so anything generated from `content/writing/` — a
@@ -91,13 +133,10 @@ function isDraftPath(pathname) {
 if (draftSlugs.length > 0) {
   for (const file of walk(OUT, (name) => !name.endsWith('.html'))) {
     const path = toUrlPath(relative(OUT, file));
-    const named = path
-      .split('/')
-      .some((segment) =>
-        draftSlugs.includes(basename(segment, extname(segment))),
-      );
 
-    if (named) {
+    // `out/` is the site root; the repository-site base path is not on disk, so
+    // an out-relative path is already a route.
+    if (isDraftAsset(`/${path}`)) {
       fail(path, `exports an asset named after a draft post: /${path}`);
     }
   }


### PR DESCRIPTION
Two confirmed disagreements in the draft-safety gates. Both claims in the brief checked out against the source.

## 1. The draft-asset scan was too broad

`scripts/verify-export.mjs` walked every non-HTML file in `out/` and flagged it when **any** path segment's basename-minus-extension matched a draft slug:

```js
path.split('/').some((segment) => draftSlugs.includes(basename(segment, extname(segment))))
```

Nothing scoped it to the places a per-post artifact can actually appear, so a draft slug colliding with any committed file anywhere in the export failed the whole build with a draft-leak message pointing at an innocent file. A draft called `photo` or `resume` took the build down over `images/photo.png` and `resume.json`.

It now matches whole path components under the directories that receive files belonging to one post:

| Root | Why |
| --- | --- |
| `POST_CARD_DIRECTORY` (`/og/writing`) | The generated share cards. Imported from the generator's own constant, so moving the cards cannot silently un-scope the gate. |
| `/writing` | The posts' route tree. It carries more than HTML — Next writes an RSC prefetch payload beside every prerendered route, so a leaked draft route also ships an `index.txt` no metadata check reads. |
| `/images/writing` | Article images, one directory per post. This one exists today (`public/images/writing/codex-desktop-app-post/`) and was not in the brief. |

The match is `<root>/<slug>`, anything beneath it, or a sibling file named for it (`<root>/<slug>.png`) — a bare prefix would also catch `<slug>-part-two.png`, which is a different post.

The gate is still the fault-injection gate it was: everything the old scan caught in those directories, it still catches.

## 2. The draft predicate disagreed with the app

`readPostCards` in `scripts/og-inputs.mjs` and the draft-slug reader in `verify-export.mjs` each skipped a post only when `data.draft === true`. `validatePostFrontmatter` in `src/lib/posts.ts` **throws** for any `draft` that is not `undefined` or a boolean.

So frontmatter `draft: 'true'` — quoted, a plausible typo — failed the site build outright while both scripts treated the post as published and `npm run og:check` instructed the author to commit a share card carrying its title.

A plain Node script cannot import the TypeScript predicate, so the rule is necessarily reimplemented. It now errs the other way. `isDraftFrontmatter` publishes only on an explicit, unambiguous "not a draft" — the key absent, or literally `false` — and every other value is withheld, so a malformed flag can never produce a published artifact: the script declines where the app throws. `verify-export.mjs` imports it rather than keeping a third copy of the rule.

## Why `public/og.meta.json` moved

`scripts/og-inputs.mjs` is one of the three sources in the card `generatorDigest`, so editing it makes `og:check` fail until the cards are regenerated. `npm run og` was re-run; the diff is the one digest line and the four PNGs are byte-identical.

## Tests

`scripts/__tests__/drafts.test.ts` (new) enumerates `draft: true`, `draft: false`, `draft: 'true'`, `draft: 'false'`, a missing key, `draft: 1`, and an empty `draft:` across three readers — the shared predicate, `readPostCards` over a fixture content directory, and `validatePostFrontmatter` — asserting the property that matters: where the site refuses to build the file, the scripts must withhold the artifact, and where the site accepts it, the two answers must be identical.

`scripts/__tests__/verify-export.test.ts` gains an innocent-collision fixture that must **pass** (drafts named `photo` and `resume` against the fixture's `images/photo.png` and `resume.json`), a malformed-draft card that must **fail**, and coverage of the RSC payload and article-image directories.

Every new test was fault-injected against the previous implementation and fails there.

## Verification

- `npm run format`, `npx biome check .`, `npx tsc --noEmit` — clean
- `npx vitest run` — **811 passed** (793 on the base, plus 18 new)
- `npm run build && npm run verify-export` — 14 pages OK against the real export
- `npm run measure-export` — 7 budgets within limits
- `npm run og:check` — current

## Out of scope, worth a look

`public/images/writing/codex-desktop-app-post/` holds three screenshots for the repository's one draft post. `public/` ships verbatim, so they are publicly fetchable today. Neither the old scan nor this one catches them, because the directory is named for the post's topic rather than its slug — an author picks that name freely. Making it catchable means either binding the directory name to the slug or reading the draft's markdown for the image paths it references; both are larger than this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)