### PR TITLE
fix(writing): keep legacy heading anchors resolving

### DIFF
--- a/app/styles/pages/writing.css
+++ b/app/styles/pages/writing.css
@@ -321,16 +321,30 @@
 
 .prose h2,
 .prose h3,
-.prose h4 {
+.prose h4,
+.prose-anchor-alias {
   scroll-margin-top: calc(var(--header-height) + var(--spacing-6));
 }
 
 @media (max-width: 735px) {
   .prose h2,
   .prose h3,
-  .prose h4 {
+  .prose h4,
+  .prose-anchor-alias {
     scroll-margin-top: calc(var(--header-height-mobile) + var(--spacing-6));
   }
+}
+
+/* A heading whose id changed when the site unified its two slug schemes keeps
+   the id it published on an empty marker inside it, so a link shared before the
+   rename still resolves. Out of flow, so it contributes nothing to layout and
+   takes its position from the top of the heading's content box — which is what
+   makes the old anchor land exactly where the new one does. It carries no text
+   and is `aria-hidden`, so it is a target and nothing else. */
+.prose-anchor-alias {
+  position: absolute;
+  width: 0;
+  height: 0;
 }
 
 .prose p {

--- a/src/components/Writing/PostContent.tsx
+++ b/src/components/Writing/PostContent.tsx
@@ -5,7 +5,7 @@ import Image from 'next/image';
 import type { ReactNode } from 'react';
 import { Children, type CSSProperties, isValidElement } from 'react';
 
-import { createHeadingId } from '@/lib/anchors';
+import { createHeadingId, planHeadingAliases } from '@/lib/anchors';
 
 interface ImageSize {
   width: number;
@@ -26,6 +26,54 @@ interface PostContentProps {
 const FALLBACK_SIZE: ImageSize = { width: 1200, height: 675 };
 
 const LANGUAGE_PREFIX = 'language-';
+
+const HEADING_TAGS = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] as const;
+
+/**
+ * Heading overrides that keep a renamed heading's previous id resolving.
+ *
+ * The canonical id stays on the heading itself; the old one rides an empty
+ * marker as the heading's first child. Inside rather than beside, because an
+ * out-of-flow element takes its static position from where it would have been —
+ * the top of the heading's content box — so `#old-slug` lands exactly where
+ * `#new-slug` lands rather than a heading margin above it.
+ */
+function headingOverrides(aliases: ReadonlyMap<string, string>) {
+  const entries = HEADING_TAGS.map(
+    (Tag) =>
+      [
+        Tag,
+        {
+          component: ({
+            id,
+            children,
+          }: {
+            id?: string;
+            children?: ReactNode;
+          }) => {
+            const legacyId = id ? aliases.get(id) : undefined;
+
+            return (
+              <Tag id={id}>
+                {legacyId ? (
+                  <span
+                    className="prose-anchor-alias"
+                    id={legacyId}
+                    // It names nothing and is not content; it exists so a link
+                    // shared before the rename still has somewhere to land.
+                    aria-hidden="true"
+                  />
+                ) : null}
+                {children}
+              </Tag>
+            );
+          },
+        },
+      ] as const,
+  );
+
+  return Object.fromEntries(entries);
+}
 
 function isRootLocalImage(src: string): boolean {
   return src.startsWith('/') && !src.startsWith('//');
@@ -106,6 +154,8 @@ export default function PostContent({
     return measuredSize ?? FALLBACK_SIZE;
   }
 
+  const aliases = planHeadingAliases(content);
+
   return (
     <Markdown
       options={{
@@ -124,6 +174,9 @@ export default function PostContent({
         // the site derived `on-using-dangerously-skip-permissions`.
         slugify: createHeadingId,
         overrides: {
+          // Unifying the scheme renamed ids that were already published, so
+          // each heading also carries whatever id it used to have.
+          ...headingOverrides(aliases),
           p: {
             component: ({ children }: { children?: ReactNode }) => {
               const items = Children.toArray(children);

--- a/src/components/Writing/__tests__/PostContent.test.tsx
+++ b/src/components/Writing/__tests__/PostContent.test.tsx
@@ -13,6 +13,18 @@ function headingIds(html: string): string[] {
   return Array.from(html.matchAll(/<h[1-6][^>]*\bid="([^"]+)"/g), (m) => m[1]);
 }
 
+/** Every id in the document, headings and alias markers alike. */
+function allIds(html: string): string[] {
+  return Array.from(html.matchAll(/\bid="([^"]+)"/g), (m) => m[1]);
+}
+
+function aliasIds(html: string): string[] {
+  return Array.from(
+    html.matchAll(/<span class="prose-anchor-alias" id="([^"]+)"/g),
+    (m) => m[1],
+  );
+}
+
 describe('PostContent', () => {
   it('renders measured local images during server rendering', () => {
     const html = renderToStaticMarkup(
@@ -196,5 +208,93 @@ describe('PostContent heading anchors', () => {
     expect(headingIds(html)).not.toContain(
       'on-using---dangerously-skip-permissions',
     );
+  });
+});
+
+describe('PostContent legacy heading anchors', () => {
+  function renderPost(slug: string): string {
+    const post = getPostBySlug(slug);
+    if (!post) {
+      throw new Error(`expected ${slug} to be published`);
+    }
+
+    return renderToStaticMarkup(
+      <PostContent
+        content={post.content}
+        imageSizes={readPostImageSizes(post.content)}
+      />,
+    );
+  }
+
+  it('keeps every id the renamed post published still resolving', () => {
+    const html = renderPost('shipping-with-claude-code');
+
+    // Measured against the live site before the slug schemes were unified.
+    for (const legacyId of [
+      'claudemd--agentsmd',
+      'on-using---dangerously-skip-permissions',
+      'plan-mode--writing-plans-to-files',
+      'browser-automation---chrome-for-interaction-playwright-mcp-for-screenshots',
+    ]) {
+      expect(allIds(html), legacyId).toContain(legacyId);
+    }
+  });
+
+  it('leaves the canonical id on the heading rather than moving it to the alias', () => {
+    const html = renderPost('shipping-with-claude-code');
+
+    for (const canonicalId of [
+      'claude-md-agents-md',
+      'on-using-dangerously-skip-permissions',
+      'plan-mode-writing-plans-to-files',
+      'browser-automation-chrome-for-interaction-playwright-mcp-for-screenshots',
+    ]) {
+      expect(headingIds(html), canonicalId).toContain(canonicalId);
+    }
+
+    expect(aliasIds(html).sort()).toEqual(
+      [
+        'browser-automation---chrome-for-interaction-playwright-mcp-for-screenshots',
+        'claudemd--agentsmd',
+        'on-using---dangerously-skip-permissions',
+        'plan-mode--writing-plans-to-files',
+      ].sort(),
+    );
+  });
+
+  it('never emits the same id twice in any published post', () => {
+    for (const post of getAllPosts()) {
+      const ids = allIds(renderPost(post.slug));
+
+      expect(new Set(ids).size, post.slug).toBe(ids.length);
+    }
+  });
+
+  it('adds nothing to a heading whose id never changed', () => {
+    const html = renderToStaticMarkup(
+      <PostContent content={'## Verification layers\n'} />,
+    );
+
+    expect(html).toBe('<h2 id="verification-layers">Verification layers</h2>');
+  });
+
+  it('hides the alias from assistive technology and from the tab order', () => {
+    const html = renderToStaticMarkup(
+      <PostContent content={'## CLAUDE.md + AGENTS.md\n'} />,
+    );
+
+    expect(html).toContain(
+      '<span class="prose-anchor-alias" id="claudemd--agentsmd" aria-hidden="true"></span>',
+    );
+    expect(html).not.toContain('tabindex');
+  });
+
+  it('suppresses an alias that would collide with another heading', () => {
+    const html = renderToStaticMarkup(
+      <PostContent content={'## Node.js\n\n## Nodejs\n'} />,
+    );
+
+    expect(aliasIds(html)).toEqual([]);
+    expect(headingIds(html)).toEqual(['node-js', 'nodejs']);
   });
 });

--- a/src/lib/__tests__/anchors.test.ts
+++ b/src/lib/__tests__/anchors.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
 import { aboutMarkdown } from '@/data/about';
-import { createHeadingId, createUniqueHeadingIds } from '../anchors';
+import { getPostBySlug } from '@/lib/posts';
+import {
+  createHeadingId,
+  createUniqueHeadingIds,
+  planHeadingAliases,
+} from '../anchors';
 
 function getAboutSectionTitles(markdown: string): string[] {
   return Array.from(
@@ -64,5 +69,71 @@ describe('createUniqueHeadingIds', () => {
 
     expect(ids.every((id) => id.length > 0)).toBe(true);
     expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe('planHeadingAliases', () => {
+  it('emits nothing when both slug schemes agree', () => {
+    expect(
+      planHeadingAliases('## Verification layers\n\n## The workflow\n'),
+    ).toEqual(new Map());
+  });
+
+  it('recovers the ids the real published post used to serve', () => {
+    const post = getPostBySlug('shipping-with-claude-code');
+    if (!post) {
+      throw new Error('expected shipping-with-claude-code to be published');
+    }
+
+    expect(planHeadingAliases(post.content)).toEqual(
+      new Map([
+        [
+          'on-using-dangerously-skip-permissions',
+          'on-using---dangerously-skip-permissions',
+        ],
+        [
+          'browser-automation-chrome-for-interaction-playwright-mcp-for-screenshots',
+          'browser-automation---chrome-for-interaction-playwright-mcp-for-screenshots',
+        ],
+        [
+          'plan-mode-writing-plans-to-files',
+          'plan-mode--writing-plans-to-files',
+        ],
+        ['claude-md-agents-md', 'claudemd--agentsmd'],
+      ]),
+    );
+  });
+
+  it('covers a heading written after the rename with no list to update', () => {
+    expect(planHeadingAliases('## Shipping `--yolo` mode\n')).toEqual(
+      new Map([['shipping-yolo-mode', 'shipping---yolo-mode']]),
+    );
+  });
+
+  it('suppresses an alias that another heading already owns as its canonical id', () => {
+    // `Node.js` used to publish `nodejs`, which the second heading now derives
+    // canonically. Two elements sharing an id is worse than one dead link, so
+    // the alias is dropped rather than emitted.
+    const aliases = planHeadingAliases('## Node.js\n\n## Nodejs\n');
+
+    expect(aliases.get('node-js')).toBeUndefined();
+    expect(aliases).toEqual(new Map());
+  });
+
+  it('gives a legacy id to only one heading when two would claim it', () => {
+    // Both of these used to publish `a--b`, from different canonical ids.
+    const aliases = planHeadingAliases('## A & B\n\n## A  B\n');
+
+    expect(aliases).toEqual(new Map([['a-and-b', 'a--b']]));
+  });
+
+  it('refuses to alias an id that appears on more than one heading', () => {
+    expect(
+      planHeadingAliases('## Using `--flag`\n\n## Using `--flag`\n'),
+    ).toEqual(new Map());
+  });
+
+  it('never proposes an empty id as a link target', () => {
+    expect(planHeadingAliases('## !!!\n')).toEqual(new Map());
   });
 });

--- a/src/lib/anchors.ts
+++ b/src/lib/anchors.ts
@@ -1,3 +1,5 @@
+import { parser } from 'markdown-to-jsx';
+
 export function createHeadingId(title: string): string {
   const slug = title
     .normalize('NFKD')
@@ -22,4 +24,72 @@ export function createUniqueHeadingIds(titles: readonly string[]): string[] {
 
     return count === 1 ? baseId : `${baseId}-${count}`;
   });
+}
+
+/**
+ * Heading ids a post used to publish, keyed by the canonical id that replaced
+ * them.
+ *
+ * Putting `createHeadingId` behind markdown-to-jsx's `slugify` unified the two
+ * slug schemes, which was right — but it also renamed four of the fifteen
+ * `<h2 id>` values on an already-published post, so every deep link anyone had
+ * shared into those sections stopped resolving. The new ids stay canonical and
+ * the old ones are re-emitted as alias targets.
+ *
+ * Nothing here is a list to maintain. markdown-to-jsx hands its own default
+ * slugifier to a custom `slugify`, so both schemes are computed for every
+ * heading from the library's own parse of the document: the legacy scheme is
+ * the one that actually shipped rather than a copy of it that could drift, and
+ * posts written after this are covered for free.
+ *
+ * An alias is only emitted when it can be emitted safely. Two elements sharing
+ * an id is worse than one dead link, so a legacy id that some other heading
+ * already claims as its canonical id — or that a second heading would claim as
+ * its own alias, or that would have to attach to an id appearing twice — is
+ * dropped instead.
+ */
+export function planHeadingAliases(markdown: string): Map<string, string> {
+  const headings: Array<{ canonical: string; legacy: string }> = [];
+
+  parser(markdown, {
+    slugify: (source, legacySlugify) => {
+      const canonical = createHeadingId(source);
+
+      headings.push({ canonical, legacy: legacySlugify(source) });
+
+      return canonical;
+    },
+  });
+
+  const canonicalCounts = new Map<string, number>();
+  for (const { canonical } of headings) {
+    canonicalCounts.set(canonical, (canonicalCounts.get(canonical) ?? 0) + 1);
+  }
+
+  const aliases = new Map<string, string>();
+  const claimed = new Set(canonicalCounts.keys());
+
+  for (const { canonical, legacy } of headings) {
+    // The default slugifier keeps nothing from a heading with no anchor-safe
+    // characters, and an empty id is not a link target.
+    if (!legacy) {
+      continue;
+    }
+
+    // Every canonical id is already claimed, so this is also what makes the
+    // common case — the two schemes agreeing — emit nothing extra.
+    if (claimed.has(legacy)) {
+      continue;
+    }
+
+    // A repeated heading has no single element to hang the alias on.
+    if (canonicalCounts.get(canonical) !== 1) {
+      continue;
+    }
+
+    aliases.set(canonical, legacy);
+    claimed.add(legacy);
+  }
+
+  return aliases;
 }


### PR DESCRIPTION
## The problem

Passing `slugify: createHeadingId` to markdown-to-jsx unified the site's two slug schemes. That was the right fix — but it also **renamed four of the fifteen `<h2 id>` values on an already-published post**, `/writing/shipping-with-claude-code/`. Anyone who had deep-linked into those sections got a dead anchor.

Measured against the live site:

| published id | id after the unification |
| --- | --- |
| `#claudemd--agentsmd` | `#claude-md-agents-md` |
| `#on-using---dangerously-skip-permissions` | `#on-using-dangerously-skip-permissions` |
| `#plan-mode--writing-plans-to-files` | `#plan-mode-writing-plans-to-files` |
| `#browser-automation---chrome-for-interaction-playwright-mcp-for-screenshots` | `#browser-automation-chrome-for-interaction-playwright-mcp-for-screenshots` |

The new ids are better and stay canonical. This makes the old ones resolve as well.

## The fix

`planHeadingAliases` in `src/lib/anchors.ts` computes **both** schemes for every heading and returns the old id wherever they disagree. Where they agree — the common case — it returns nothing and no extra markup is emitted.

There is **no hand-maintained map**. markdown-to-jsx hands its own default slugifier to a custom `slugify`, so the legacy scheme is the library's own rather than a copy of it that could drift, and it is read off the library's own parse of the document. Every existing post and every future one is covered with nothing to update.

The canonical id stays on the `<h2>`. The old id rides an empty marker as the heading's first child:

```html
<h2 id="claude-md-agents-md"><span class="prose-anchor-alias" id="claudemd--agentsmd" aria-hidden="true"></span>CLAUDE.md + AGENTS.md</h2>
```

Inside the heading rather than beside it on purpose: an out-of-flow element takes its position from where it would have been, which inside the heading is the top of its content box. A sibling would sit a 3rem heading margin higher and land somewhere else.

## Duplicate ids are impossible by construction

Two elements sharing an id is worse than one dead link, so an alias is dropped rather than emitted when it cannot be emitted safely:

- the legacy id is some **other** heading's canonical id (`## Node.js` + `## Nodejs`)
- a second heading would claim the **same** legacy id (first one wins, the rest are dropped)
- the canonical id appears **twice**, so there is no single element to hang it on
- the legacy slugifier produced an **empty** string, which is not a link target

Each case has its own test, plus one asserting that no id appears twice in the rendered output of any published post.

## Verification

`npm run format`, `npx biome check .`, `npx tsc --noEmit` all clean. `npx vitest run`: **806 passed** (793 on the base + 13 new).

Beyond the suite, checked in Chrome against the real `npm run build` export:

- navigating to `#claudemd--agentsmd` on a cold load lands at `scrollY 8435`, with the heading 80px below the viewport top — `--header-height-mobile` + `--spacing-6`, exactly the canonical landing
- all four legacy/canonical pairs resolve to **pixel-identical** scroll positions, on cold load and on in-page hash change
- document height, heading position, heading height and `.prose` height are **byte-identical** with the markers removed and restored
- `tabIndex` is `-1` (not a tab stop) and `aria-hidden="true"`
- 28 ids in the exported page, **zero duplicates**

## Files

- `src/lib/anchors.ts` — `planHeadingAliases`
- `src/components/Writing/PostContent.tsx` — heading overrides for `h1`–`h6`
- `app/styles/pages/writing.css` — `.prose-anchor-alias`, added to the existing `scroll-margin-top` rules so it tracks the heading in both breakpoints
- tests for both modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)
