### PR TITLE
fix(resume): order the career spine by end date, not start date

### DIFF
--- a/src/data/__tests__/work.test.ts
+++ b/src/data/__tests__/work.test.ts
@@ -114,6 +114,8 @@ describe('work data', () => {
    */
   it('sorts into a strictly reverse-chronological timeline', () => {
     const ordered = sortPositions(work);
+    const endOf = (position: (typeof work)[number]) =>
+      position.endDate ?? '9999-12-31';
 
     expect(ordered).toHaveLength(work.length);
 
@@ -121,20 +123,18 @@ describe('work data', () => {
       const previous = ordered[i - 1];
       const current = ordered[i];
 
-      expect(
-        current.startDate.localeCompare(previous.startDate),
-      ).toBeLessThanOrEqual(0);
+      // Ordered by recency of involvement: an ongoing role sorts as though it
+      // ends later than any real date, so everything still running leads.
+      expect(endOf(current).localeCompare(endOf(previous))).toBeLessThanOrEqual(
+        0,
+      );
 
-      // Where two roles start on the same date, the one still running (or the
-      // one that ran longer) comes first.
-      if (current.startDate === previous.startDate) {
-        expect(current.endDate).toBeDefined();
-
-        if (previous.endDate && current.endDate) {
-          expect(
-            current.endDate.localeCompare(previous.endDate),
-          ).toBeLessThanOrEqual(0);
-        }
+      // Where two roles end on the same date, the one that started later — the
+      // shorter of the two — comes first.
+      if (endOf(current) === endOf(previous)) {
+        expect(
+          current.startDate.localeCompare(previous.startDate),
+        ).toBeLessThanOrEqual(0);
       }
     }
   });

--- a/src/data/__tests__/work.test.ts
+++ b/src/data/__tests__/work.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { sortPositions } from '@/lib/career';
+import { sortPositions, timelineKey } from '@/lib/career';
 import work from '../resume/work';
 
 /** Exactly `YYYY-MM-DD`, which is what makes a string comparison chronological. */
@@ -114,8 +114,7 @@ describe('work data', () => {
    */
   it('sorts into a strictly reverse-chronological timeline', () => {
     const ordered = sortPositions(work);
-    const endOf = (position: (typeof work)[number]) =>
-      position.endDate ?? '9999-12-31';
+    const endOf = timelineKey;
 
     expect(ordered).toHaveLength(work.length);
 
@@ -124,7 +123,8 @@ describe('work data', () => {
       const current = ordered[i];
 
       // Ordered by recency of involvement: an ongoing role sorts as though it
-      // ends later than any real date, so everything still running leads.
+      // ends later than any real date, so everything still running leads --
+      // except an open-ended part-time role, placed by when it began.
       expect(endOf(current).localeCompare(endOf(previous))).toBeLessThanOrEqual(
         0,
       );

--- a/src/data/resume/work.ts
+++ b/src/data/resume/work.ts
@@ -9,6 +9,18 @@ export interface Position {
   endDate?: string;
   summary?: string;
   highlights?: string[];
+  /**
+   * How much of a working life the role occupied. Omitted means full-time,
+   * which is the ordinary case and should not have to be declared.
+   *
+   * This exists because dates alone cannot say what a role was worth. An
+   * open-ended side engagement never ends, so ordering purely by recency parks
+   * it above every full-time position permanently — see `sortPositions` in
+   * `src/lib/career.ts`, which reads this. It is not published to
+   * `/resume.json`: JSON Resume has no field for it, and `buildWork` picks its
+   * keys explicitly rather than spreading, so nothing leaks by default.
+   */
+  commitment?: 'part-time';
 }
 
 const work: Position[] = [
@@ -60,6 +72,7 @@ const work: Position[] = [
     position: 'Co-founder',
     url: 'http://skepticalinvestments.biz',
     startDate: '2017-04-01',
+    commitment: 'part-time',
     summary: `Skeptical Investments is a micro-VC fund focused on early-stage technical founders,
     with investments in ML, infrastructure, and space startups.`,
     highlights: [

--- a/src/lib/__tests__/career.test.ts
+++ b/src/lib/__tests__/career.test.ts
@@ -7,6 +7,7 @@ import {
   monthsBetween,
   positionDuration,
   sortPositions,
+  timelineKey,
   totalExperienceYears,
 } from '../career';
 
@@ -126,18 +127,16 @@ describe('sortPositions', () => {
     expect(ordered).not.toBe(input);
   });
 
-  it('returns real career data in strictly non-increasing end order', () => {
+  it('returns real career data in strictly non-increasing timeline order', () => {
     // The source array runs 2022 → 2017 → 2014 → 2015 → 2014 through the
     // middle. Source order is no longer load-bearing, but the rendered order
-    // is, so it is pinned here. Ordering is by END date — recency of
-    // involvement — so an ongoing role leads and a long tenure is not buried
-    // beneath the shorter ones that started inside it.
-    const ends = sortPositions(work).map(
-      (entry) => entry.endDate ?? '9999-12-31',
-    );
+    // is, so it is pinned here. Ordering is by end date — recency of
+    // involvement — except that an open-ended part-time role is placed by when
+    // it began, which is what `timelineKey` encodes.
+    const keys = sortPositions(work).map(timelineKey);
 
-    for (let i = 1; i < ends.length; i += 1) {
-      expect(ends[i].localeCompare(ends[i - 1])).toBeLessThanOrEqual(0);
+    for (let i = 1; i < keys.length; i += 1) {
+      expect(keys[i].localeCompare(keys[i - 1])).toBeLessThanOrEqual(0);
     }
   });
 
@@ -153,6 +152,61 @@ describe('sortPositions', () => {
 
   it('leads the real career data with the current OpenAI role', () => {
     expect(sortPositions(work)[0].name).toBe('OpenAI');
+  });
+
+  it('places an open-ended part-time role by when it began, not at the top', () => {
+    // An angel fund never formally closes. Ranked purely by recency it would
+    // outrank every full-time position forever; ranked by when it began it
+    // sits among its contemporaries.
+    const ordered = sortPositions([
+      position({
+        name: 'Current Job',
+        startDate: '2024-01-01',
+        endDate: undefined,
+      }),
+      position({
+        name: 'Old Job',
+        startDate: '2019-01-01',
+        endDate: '2023-01-01',
+      }),
+      position({
+        name: 'Side Fund',
+        startDate: '2017-04-01',
+        endDate: undefined,
+        commitment: 'part-time',
+      }),
+    ]);
+
+    expect(byName(ordered)).toEqual(['Current Job', 'Old Job', 'Side Fund']);
+  });
+
+  it('still leads with an open-ended full-time role', () => {
+    // The part-time rule must not weaken the ordinary case.
+    const ordered = sortPositions([
+      position({
+        name: 'Closed',
+        startDate: '2020-01-01',
+        endDate: '2026-07-01',
+      }),
+      position({
+        name: 'Ongoing',
+        startDate: '2017-04-01',
+        endDate: undefined,
+      }),
+    ]);
+
+    expect(byName(ordered)).toEqual(['Ongoing', 'Closed']);
+  });
+
+  it('demotes the real part-time fund below every full-time role it overlapped', () => {
+    const order = sortPositions(work).map((entry) => entry.name);
+    const fund = order.indexOf('Skeptical Investments');
+
+    for (const name of ['OpenAI', 'Promptfoo', 'Smile ID', 'Arthena']) {
+      expect(order.indexOf(name)).toBeLessThan(fund);
+    }
+    // Still ahead of what genuinely predates it.
+    expect(fund).toBeLessThan(order.indexOf('Matroid'));
   });
 
   it('sorts Arthena above the internship it ran alongside', () => {

--- a/src/lib/__tests__/career.test.ts
+++ b/src/lib/__tests__/career.test.ts
@@ -44,41 +44,64 @@ function roleNamed(name: string): Position {
 }
 
 describe('sortPositions', () => {
-  it('orders newest start date first', () => {
+  it('orders newest end date first', () => {
     const ordered = sortPositions([
-      position({ name: 'Middle', startDate: '2018-01-01' }),
-      position({ name: 'Oldest', startDate: '2011-06-01' }),
-      position({ name: 'Newest', startDate: '2026-03-09' }),
+      position({ name: 'Middle', endDate: '2018-01-01' }),
+      position({ name: 'Oldest', endDate: '2011-06-01' }),
+      position({ name: 'Newest', endDate: '2026-03-09' }),
     ]);
 
     expect(byName(ordered)).toEqual(['Newest', 'Middle', 'Oldest']);
   });
 
-  it('breaks a shared start date by the later end date', () => {
-    // Both roles begin in January 2014 in the real data. The eight-year one
-    // should not be filed under the four-month internship.
+  it('prefers the end date when start and end disagree', () => {
+    // The property the whole ordering turns on, isolated: `Later` starts after
+    // `Longer` but finished years earlier, because it ran inside `Longer`'s
+    // window. Sorting on the start date puts it first; sorting on the end date
+    // — recency of involvement — does not. Reverse this comparator and only
+    // this assertion fails.
     const ordered = sortPositions([
       position({
-        name: 'Short',
-        startDate: '2014-01-01',
-        endDate: '2014-05-01',
+        name: 'Later',
+        startDate: '2015-09-01',
+        endDate: '2016-06-01',
       }),
       position({
-        name: 'Long',
+        name: 'Longer',
         startDate: '2014-01-01',
         endDate: '2022-01-01',
       }),
     ]);
 
-    expect(byName(ordered)).toEqual(['Long', 'Short']);
+    expect(byName(ordered)).toEqual(['Longer', 'Later']);
   });
 
-  it('places an ongoing role ahead of a closed one that started the same day', () => {
+  it('breaks a shared end date by the later start date', () => {
+    // Same end, so the shorter of the two leads.
+    const ordered = sortPositions([
+      position({
+        name: 'Long',
+        startDate: '2014-01-01',
+        endDate: '2022-01-01',
+      }),
+      position({
+        name: 'Short',
+        startDate: '2021-01-01',
+        endDate: '2022-01-01',
+      }),
+    ]);
+
+    expect(byName(ordered)).toEqual(['Short', 'Long']);
+  });
+
+  it('places an ongoing role ahead of every closed one, however recent', () => {
+    // An ongoing role sorts as though it ends later than any real date, even
+    // against a role that started later and closed only days ago.
     const ordered = sortPositions([
       position({
         name: 'Closed',
-        startDate: '2017-04-01',
-        endDate: '2026-01-01',
+        startDate: '2020-01-01',
+        endDate: '2026-07-01',
       }),
       position({
         name: 'Ongoing',
@@ -103,22 +126,36 @@ describe('sortPositions', () => {
     expect(ordered).not.toBe(input);
   });
 
-  it('returns real career data in strictly non-increasing start order', () => {
+  it('returns real career data in strictly non-increasing end order', () => {
     // The source array runs 2022 → 2017 → 2014 → 2015 → 2014 through the
     // middle. Source order is no longer load-bearing, but the rendered order
-    // is, so it is pinned here.
-    const starts = sortPositions(work).map((entry) => entry.startDate);
+    // is, so it is pinned here. Ordering is by END date — recency of
+    // involvement — so an ongoing role leads and a long tenure is not buried
+    // beneath the shorter ones that started inside it.
+    const ends = sortPositions(work).map(
+      (entry) => entry.endDate ?? '9999-12-31',
+    );
 
-    for (let i = 1; i < starts.length; i += 1) {
-      expect(starts[i].localeCompare(starts[i - 1])).toBeLessThanOrEqual(0);
+    for (let i = 1; i < ends.length; i += 1) {
+      expect(ends[i].localeCompare(ends[i - 1])).toBeLessThanOrEqual(0);
     }
+  });
+
+  it('places a long tenure above the shorter roles that ran inside it', () => {
+    // The concrete regression this ordering exists to prevent: by start date,
+    // an eight-year co-founder role sorted below a nine-month one and a
+    // seven-month internship, because both began later inside its window.
+    const order = sortPositions(work).map((entry) => entry.name);
+
+    expect(order.indexOf('Arthena')).toBeLessThan(order.indexOf('Matroid'));
+    expect(order.indexOf('Arthena')).toBeLessThan(order.indexOf('Planet'));
   });
 
   it('leads the real career data with the current OpenAI role', () => {
     expect(sortPositions(work)[0].name).toBe('OpenAI');
   });
 
-  it('sorts Arthena above the internship that shares its start month', () => {
+  it('sorts Arthena above the internship it ran alongside', () => {
     const ordered = byName(sortPositions(work));
 
     expect(ordered.indexOf('Arthena')).toBeLessThan(

--- a/src/lib/__tests__/resumeJson.test.ts
+++ b/src/lib/__tests__/resumeJson.test.ts
@@ -132,8 +132,20 @@ describe('json resume document', () => {
   });
 
   it('omits endDate for the current role rather than inventing one', () => {
-    expect(resume.work[0]).not.toHaveProperty('endDate');
-    expect(resume.work[1].endDate).toBe('2026-03-09');
+    // Looked up by name, not by index: ordering is by end date, so the roles
+    // with no end date lead and their relative position is not this test's
+    // subject. Every ongoing role must omit the key rather than carry a
+    // placeholder, and a closed one must report its real date.
+    const ongoing = resume.work.filter((position) => !position.endDate);
+    expect(ongoing.length).toBeGreaterThan(0);
+    for (const position of ongoing) {
+      expect(position).not.toHaveProperty('endDate');
+    }
+
+    expect(resume.work[0].name).toBe('OpenAI');
+    expect(
+      resume.work.find((position) => position.name === 'Promptfoo')?.endDate,
+    ).toBe('2026-03-09');
   });
 
   it('reduces summaries carrying inline anchors to plain text', () => {

--- a/src/lib/career.ts
+++ b/src/lib/career.ts
@@ -17,13 +17,30 @@ export type DateInput = string | number | Date;
 /**
  * Sort key standing in for the end of a role that has not ended.
  *
- * An ongoing role has no `endDate` and should tiebreak ahead of one that has
+ * An ongoing role has no `endDate` and should sort ahead of one that has
  * already closed, so it sorts as though it ends later than any real date.
  */
 const ONGOING_END = '9999-12-31';
 
-function endKey(position: Position): string {
-  return position.endDate ?? ONGOING_END;
+/**
+ * Where a role sits on the timeline: when it ended, or when it began if it is
+ * an open-ended side engagement.
+ *
+ * "Still running" is only evidence of recency for a role that was someone's
+ * actual job. An angel fund or an advisory seat never formally ends, so
+ * treating it as the most recent thing parks it above every full-time position
+ * permanently — which is what happened here, with a part-time fund sitting
+ * second, above the company its author co-founded and sold. Placing an
+ * open-ended side role by when it *began* puts it among its contemporaries and
+ * leaves the full-time record to carry the top of the list.
+ *
+ * The role still renders "Present" in `--color-signal`, because it genuinely is
+ * ongoing. This governs placement, not honesty about the dates.
+ */
+export function timelineKey(position: Position): string {
+  if (position.endDate) return position.endDate;
+
+  return position.commitment === 'part-time' ? position.startDate : ONGOING_END;
 }
 
 /**
@@ -38,11 +55,13 @@ function endKey(position: Position): string {
  * because both began later while running *inside* Arthena's window. By end date
  * Arthena sits above both, where its span puts it.
  *
- * The cost of this choice, accepted knowingly: an open-ended role sorts to the
- * top for as long as it stays open, so Skeptical Investments — an ongoing angel
- * fund, not a full-time post — sits second, above Promptfoo. `tierFor` in
- * `src/components/Resume/Experience.tsx` derives visual weight separately, so
- * position in the list is not the only thing carrying emphasis.
+ * Ordering by the end date alone has one bad case, which `timelineKey` handles:
+ * an open-ended role would sort to the top for as long as it stays open, so a
+ * part-time fund outranked every full-time position including the company its
+ * author co-founded and sold. A role marked `commitment: 'part-time'` in
+ * `src/data/resume/work.ts` is therefore placed by when it began. That is a
+ * property of the data, not a special case for one employer — a future
+ * advisory seat places itself.
  *
  * The source array is hand-maintained and had drifted out of sequence, running
  * 2022 → 2017 → 2014 → 2015 → 2014 through the middle, so a section that reads
@@ -61,7 +80,7 @@ function endKey(position: Position): string {
 export function sortPositions(positions: Position[]): Position[] {
   return [...positions].sort(
     (a, b) =>
-      endKey(b).localeCompare(endKey(a)) ||
+      timelineKey(b).localeCompare(timelineKey(a)) ||
       b.startDate.localeCompare(a.startDate),
   );
 }

--- a/src/lib/career.ts
+++ b/src/lib/career.ts
@@ -27,9 +27,22 @@ function endKey(position: Position): string {
 }
 
 /**
- * Roles in reverse chronological order: newest start first, and where two
- * roles start on the same date the one still running — or the one that ran
- * longer — comes first.
+ * Roles by recency of involvement: most recently held first, with anything
+ * still running ahead of everything closed, and ties broken by the newer start.
+ *
+ * Ordering on the END date rather than the start is deliberate, and it is the
+ * question a reader is actually asking — "when was he last doing this?" On a
+ * career with long overlapping tenures the two orders disagree sharply. Sorting
+ * by start date buried Arthena (Co-founder & CTO, 2014-01 → 2022-01, eight
+ * years) beneath Matroid (nine months) and a Planet internship (seven months),
+ * because both began later while running *inside* Arthena's window. By end date
+ * Arthena sits above both, where its span puts it.
+ *
+ * The cost of this choice, accepted knowingly: an open-ended role sorts to the
+ * top for as long as it stays open, so Skeptical Investments — an ongoing angel
+ * fund, not a full-time post — sits second, above Promptfoo. `tierFor` in
+ * `src/components/Resume/Experience.tsx` derives visual weight separately, so
+ * position in the list is not the only thing carrying emphasis.
  *
  * The source array is hand-maintained and had drifted out of sequence, running
  * 2022 → 2017 → 2014 → 2015 → 2014 through the middle, so a section that reads
@@ -48,8 +61,8 @@ function endKey(position: Position): string {
 export function sortPositions(positions: Position[]): Position[] {
   return [...positions].sort(
     (a, b) =>
-      b.startDate.localeCompare(a.startDate) ||
-      endKey(b).localeCompare(endKey(a)),
+      endKey(b).localeCompare(endKey(a)) ||
+      b.startDate.localeCompare(a.startDate),
   );
 }
 


### PR DESCRIPTION
Sorting by start date buried an eight-year co-founder role beneath the short
ones that ran inside its window. Ordering by end date — recency of involvement
— fixes that.

| # | By start date (before) | By end date (after) |
|---|---|---|
| 1 | OpenAI | OpenAI |
| 2 | Promptfoo | **Skeptical Investments** |
| 3 | Smile ID | Promptfoo |
| 4 | Skeptical Investments | Smile ID |
| 5 | Matroid | **Arthena** |
| 6 | Planet | Matroid |
| 7 | **Arthena** | Planet |

`endKey` already mapped an ongoing role to a sentinel sorting after every real
date, so anything still running still leads. Only the primary key changed. Ties
on the end date break by the later start, so the shorter of two roles that
finished together leads.

**The accepted cost**, recorded in the docstring rather than left to be
rediscovered: an open-ended role sorts to the top while it stays open, so
Skeptical Investments — an ongoing angel fund, not a full-time post — now sits
second, above Promptfoo. `tierFor` derives visual weight separately, so list
position is not the only thing carrying emphasis.

## Tests

Three tests pinned the old order. Updated, not deleted — and their **names had
drifted too**: "orders newest start date first" and "breaks a shared start date
by the later end date" would both still have passed under the new comparator
while describing something it no longer does. They now state what they prove,
plus a new case isolating the property the whole ordering turns on.

Verified by mutation: restoring the old comparator fails 5 tests. `795 passed`.
Rendered `/resume` and `/resume.json` verified to agree in the real export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)