### PR TITLE
fix(theme): stop theme-color disagreeing with the rendered theme

### DIFF
--- a/app/__tests__/theme-color.test.ts
+++ b/app/__tests__/theme-color.test.ts
@@ -1,7 +1,10 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it, vi } from 'vitest';
 
+import { THEME_COLOR_META_SELECTOR } from '@/lib/theme';
 import { readColorToken } from '@/lib/tokens';
-import { viewport } from '../layout';
+import RootLayout, { viewport } from '../layout';
 
 // `next/font/local` only exists as a build-time transform, so importing the
 // root layout for its `viewport` export needs it stubbed. The stub returns the
@@ -12,11 +15,19 @@ vi.mock('next/font/local', () => ({
   default: () => ({ variable: 'font-mock', className: 'font-mock', style: {} }),
 }));
 
+const LIGHT = readColorToken('--color-bg-alt', 'light');
+const DARK = readColorToken('--color-bg-alt', 'dark');
+
 /**
  * The export shipped with no `theme-color` at all, so mobile browsers painted
  * their chrome from their own default rather than from the page. A single
  * unscoped value only fixes that for one of the two themes, which is why this
  * pins the media-scoped pair rather than merely pinning that a value exists.
+ *
+ * The pair is scoped by the *device* preference, which is not what this site
+ * themes off — `<html data-theme>` is, and a visitor can pin it against the
+ * device. So the pair is what the page ships for a reader with no JavaScript,
+ * and the bootstrap below repoints it at the rendered theme for everyone else.
  */
 describe('theme-color', () => {
   const themeColor = viewport.themeColor;
@@ -24,15 +35,13 @@ describe('theme-color', () => {
   it('declares one media-scoped value per colour scheme', () => {
     expect(Array.isArray(themeColor)).toBe(true);
     expect(themeColor).toEqual([
-      {
-        media: '(prefers-color-scheme: light)',
-        color: readColorToken('--color-bg-alt', 'light'),
-      },
-      {
-        media: '(prefers-color-scheme: dark)',
-        color: readColorToken('--color-bg-alt', 'dark'),
-      },
+      { media: '(prefers-color-scheme: light)', color: LIGHT },
+      { media: '(prefers-color-scheme: dark)', color: DARK },
     ]);
+  });
+
+  it('declares two different colours, so the scoping does something', () => {
+    expect(LIGHT).not.toBe(DARK);
   });
 
   /**
@@ -48,5 +57,34 @@ describe('theme-color', () => {
 
     expect(values).not.toContain(readColorToken('--color-bg', 'light'));
     expect(values).not.toContain(readColorToken('--color-bg', 'dark'));
+  });
+
+  describe('bootstrap', () => {
+    // No `s` flag: `target` here is es2015, which does not have one.
+    const head = /<head>([\s\S]*?)<\/head>/.exec(
+      renderToStaticMarkup(createElement(RootLayout, { children: null })),
+    )?.[1];
+
+    /**
+     * A literal `<script>` with the body inline, which is the only kind that
+     * runs before the page is painted. `<Script strategy="beforeInteractive">`
+     * looks like it should be — it is what this used to be — but in the App
+     * Router it serialises the body into `self.__next_s` for Next's
+     * `appBootstrap` to run once the client chunks have loaded, which is long
+     * after first paint. Nothing else in the head is deferred like that, so
+     * this assertion is the only place the distinction is visible.
+     */
+    it('ships the theme bootstrap as a parser-blocking inline script', () => {
+      expect(head).toMatch(/<script id="theme-init">\(function\(\)\{/);
+      expect(head).not.toContain('__next_s');
+    });
+
+    it('carries both chrome colours and the tags they belong to', () => {
+      // Read at build from the same token the pair above declares, so the
+      // scripted value and the no-JavaScript value cannot disagree.
+      expect(head).toContain(JSON.stringify(LIGHT));
+      expect(head).toContain(JSON.stringify(DARK));
+      expect(head).toContain(THEME_COLOR_META_SELECTOR);
+    });
   });
 });

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata, Viewport } from 'next';
-import Script from 'next/script';
 
 import { SiteSchema } from '@/components/Schema';
 import GoogleAnalytics from '@/components/Template/GoogleAnalytics';
@@ -7,30 +6,44 @@ import Navigation from '@/components/Template/Navigation';
 import { MAIN_CONTENT_ID } from '@/components/Template/PageWrapper';
 import ScrollToTop from '@/components/Template/ScrollToTop';
 import { sharedOpenGraph, sharedTwitter } from '@/lib/metadata';
-import { themeInitScript } from '@/lib/theme';
+import {
+  THEME_COLOR_TOKEN,
+  type ThemeColors,
+  themeInitScript,
+} from '@/lib/theme';
 import { readColorToken } from '@/lib/tokens';
 import { AUTHOR_NAME, SITE_DESCRIPTION, SITE_URL } from '@/lib/utils';
 import { bricolage, jetbrainsMono, newsreader } from './fonts';
 import './tailwind.css';
 
 /**
+ * The colour immediately under the browser's own chrome, per theme, read from
+ * the stylesheets at build time rather than typed here so it cannot drift from
+ * the tokens. `--color-bg-alt` is the page background the sticky header tints;
+ * `--color-bg` is the raised surface and would put two colours side by side.
+ */
+const CHROME_COLORS: ThemeColors = {
+  light: readColorToken(THEME_COLOR_TOKEN, 'light'),
+  dark: readColorToken(THEME_COLOR_TOKEN, 'dark'),
+};
+
+/**
  * `theme-color` paints the browser's own chrome — the Android address bar, the
- * Safari toolbar — so it has to be the colour immediately under it, which is
- * the page background the sticky header tints. One unscoped value is wrong in
- * whichever theme it was not picked for, so both are declared and scoped by
- * `prefers-color-scheme`. The values are read from the stylesheets at build
- * time rather than typed here, so they cannot drift from the tokens.
+ * Safari toolbar. One unscoped value is wrong in whichever theme it was not
+ * picked for, so both are declared and scoped by `prefers-color-scheme`.
+ *
+ * That scoping is the *device* preference, and nothing in this project themes
+ * off the device preference: the rendered theme is `<html data-theme>`, which
+ * a visitor can pin to either value and which outlives the tab. So this pair
+ * is the no-JavaScript answer — the best one available with no way to read the
+ * stored choice — and the bootstrap below repoints both tags at the theme
+ * actually being painted. Left alone, a visitor reading in dark mode on a
+ * light device got a white address bar over a black page.
  */
 export const viewport: Viewport = {
   themeColor: [
-    {
-      media: '(prefers-color-scheme: light)',
-      color: readColorToken('--color-bg-alt', 'light'),
-    },
-    {
-      media: '(prefers-color-scheme: dark)',
-      color: readColorToken('--color-bg-alt', 'dark'),
-    },
+    { media: '(prefers-color-scheme: light)', color: CHROME_COLORS.light },
+    { media: '(prefers-color-scheme: dark)', color: CHROME_COLORS.dark },
   ],
 };
 
@@ -105,13 +118,23 @@ export default function RootLayout({
       suppressHydrationWarning
     >
       <head>
-        {/* CSP-safe theme initialization — prevents flash on load, and stamps
-            the *choice* alongside the resolved theme so the header's theme
-            control can render its own state from the HTML instead of waiting
-            for hydration. Built from the same constants the control uses. */}
-        <Script id="theme-init" strategy="beforeInteractive">
-          {themeInitScript()}
-        </Script>
+        {/* Theme bootstrap — prevents flash on load, stamps the *choice*
+            alongside the resolved theme so the header's theme control can
+            render its own state from the HTML instead of waiting for
+            hydration, and repoints the `theme-color` tags above at that same
+            theme. Built from the same constants the control uses.
+
+            A plain inline script, not `<Script strategy="beforeInteractive">`:
+            in the App Router that strategy serialises the body into
+            `self.__next_s` and Next's `appBootstrap` runs it once the client
+            chunks have loaded, which is long after first paint. Only a
+            parser-blocking script runs before the page is painted, which is
+            the entire point of this one. It sits after the metadata Next
+            emits, so the tags it queries are already parsed. */}
+        <script
+          id="theme-init"
+          dangerouslySetInnerHTML={{ __html: themeInitScript(CHROME_COLORS) }}
+        />
         <SiteSchema />
       </head>
       <body>

--- a/src/components/Template/ThemeToggle.tsx
+++ b/src/components/Template/ThemeToggle.tsx
@@ -9,6 +9,7 @@ import {
   readStoredThemeChoice,
   resolveTheme,
   storeThemeChoice,
+  syncThemeColor,
   THEME_ATTRIBUTE,
   THEME_CHOICE_ATTRIBUTE,
   THEME_CHOICES,
@@ -93,6 +94,16 @@ export default function ThemeToggle() {
     if (resolved !== null) {
       root.setAttribute(THEME_ATTRIBUTE, resolved);
     }
+
+    // The browser chrome is painted from `theme-color` meta tags, which the
+    // export scopes by `prefers-color-scheme` because that is all a static
+    // file can do. Nothing else here themes off the device, so once the
+    // attribute above is settled the tags have to be told what it says —
+    // including when the device flips underneath a `system` choice, which is
+    // the other reason this runs on every change rather than once at mount.
+    // Reads the token back out of the cascade, so it cannot name a colour the
+    // page is not painted with.
+    syncThemeColor(document);
   }, [choice, systemScheme]);
 
   const cycle = useCallback(() => {

--- a/src/components/__tests__/Template/ThemeToggle.test.tsx
+++ b/src/components/__tests__/Template/ThemeToggle.test.tsx
@@ -9,8 +9,10 @@ import {
   DARK_SCHEME_QUERY,
   THEME_ATTRIBUTE,
   THEME_CHOICE_ATTRIBUTE,
+  THEME_COLOR_TOKEN,
   THEME_STORAGE_KEY,
 } from '@/lib/theme';
+import { readColorToken } from '@/lib/tokens';
 import ThemeToggle from '../../Template/ThemeToggle';
 
 const SYSTEM_LABEL = 'Theme: system. Switch to light.';
@@ -71,6 +73,12 @@ const NAVIGATION_CSS = readFileSync(
   'utf8',
 );
 
+/** The real chrome colours, one per theme, as `app/layout.tsx` reads them. */
+const CHROME_COLORS = {
+  light: readColorToken(THEME_COLOR_TOKEN, 'light'),
+  dark: readColorToken(THEME_COLOR_TOKEN, 'dark'),
+} as const;
+
 const unhydrated: Element[] = [];
 
 /**
@@ -94,6 +102,35 @@ function renderUnhydrated(choice: string | null): Element {
   if (!button) throw new Error('no theme toggle in the server markup');
 
   return button;
+}
+
+/**
+ * The `<head>` a real page has: the media-scoped `theme-color` pair from the
+ * static export, and the token declarations `data-theme` switches between.
+ */
+function renderHead(): void {
+  const style = document.createElement('style');
+  style.textContent =
+    `:root{${THEME_COLOR_TOKEN}:${CHROME_COLORS.light};}` +
+    `[${THEME_ATTRIBUTE}='dark']{${THEME_COLOR_TOKEN}:${CHROME_COLORS.dark};}`;
+  document.head.append(style);
+  unhydrated.push(style);
+
+  for (const scheme of ['light', 'dark'] as const) {
+    const meta = document.createElement('meta');
+    meta.setAttribute('name', 'theme-color');
+    meta.setAttribute('media', `(prefers-color-scheme: ${scheme})`);
+    meta.setAttribute('content', CHROME_COLORS[scheme]);
+    document.head.append(meta);
+    unhydrated.push(meta);
+  }
+}
+
+/** What the address bar is painted with, according to every tag on the page. */
+function chromeColors(): string[] {
+  return [...document.querySelectorAll('meta[name="theme-color"]')].map(
+    (meta) => meta.getAttribute('content') ?? '',
+  );
 }
 
 function visibleStates(): (string | null)[] {
@@ -286,6 +323,23 @@ describe('ThemeToggle', () => {
       expect(root().getAttribute(THEME_ATTRIBUTE)).toBe('dark');
     });
 
+    it('repaints the browser chrome when the device flips', () => {
+      // `theme-color` is scoped by `prefers-color-scheme`, so the tags would
+      // follow this on their own — but they are no longer left to, and a
+      // pinned pair here would be stale for the rest of the visit.
+      renderHead();
+      const media = stubColorScheme(false);
+      render(<ThemeToggle />);
+      expect(chromeColors()).toEqual([
+        CHROME_COLORS.light,
+        CHROME_COLORS.light,
+      ]);
+
+      media.flipTo(true);
+
+      expect(chromeColors()).toEqual([CHROME_COLORS.dark, CHROME_COLORS.dark]);
+    });
+
     it('leaves the bootstrap theme alone when the device cannot be read', () => {
       // Guessing light here is exactly the flash the bootstrap exists to avoid.
       root().setAttribute(THEME_ATTRIBUTE, 'dark');
@@ -300,6 +354,84 @@ describe('ThemeToggle', () => {
 
       expect(root().getAttribute(THEME_ATTRIBUTE)).toBe('dark');
       expect(root().getAttribute(THEME_CHOICE_ATTRIBUTE)).toBe('system');
+    });
+  });
+
+  describe('browser chrome', () => {
+    // The address bar and the toolbar are painted from `theme-color`, which
+    // only the device preference can scope. A visitor who picks a theme is
+    // saying the device preference does not apply to this page, so every
+    // change of `data-theme` has to be carried to the tags as well.
+    it('follows a chosen theme against the device', () => {
+      renderHead();
+      stubColorScheme(true);
+      render(<ThemeToggle />);
+      expect(chromeColors()).toEqual([CHROME_COLORS.dark, CHROME_COLORS.dark]);
+
+      // system -> light, on a device that prefers dark.
+      fireEvent.click(toggle());
+
+      expect(root().getAttribute(THEME_ATTRIBUTE)).toBe('light');
+      expect(chromeColors()).toEqual([
+        CHROME_COLORS.light,
+        CHROME_COLORS.light,
+      ]);
+    });
+
+    it('hands the chrome back to the device on the way round to system', () => {
+      renderHead();
+      const media = stubColorScheme(false);
+      render(<ThemeToggle />);
+
+      // system -> light -> dark, pinned against a light device.
+      fireEvent.click(toggle());
+      fireEvent.click(toggle());
+      expect(chromeColors()).toEqual([CHROME_COLORS.dark, CHROME_COLORS.dark]);
+
+      fireEvent.click(toggle());
+      expect(root().getAttribute(THEME_CHOICE_ATTRIBUTE)).toBe('system');
+      expect(chromeColors()).toEqual([
+        CHROME_COLORS.light,
+        CHROME_COLORS.light,
+      ]);
+
+      media.flipTo(true);
+      expect(chromeColors()).toEqual([CHROME_COLORS.dark, CHROME_COLORS.dark]);
+    });
+
+    it('never names a colour the page is not painted with', () => {
+      renderHead();
+      stubColorScheme(true);
+      render(<ThemeToggle />);
+
+      for (let press = 0; press < 6; press += 1) {
+        const painted =
+          root().getAttribute(THEME_ATTRIBUTE) === 'dark'
+            ? CHROME_COLORS.dark
+            : CHROME_COLORS.light;
+
+        expect(chromeColors()).toEqual([painted, painted]);
+        fireEvent.click(toggle());
+      }
+    });
+
+    it('leaves the scoped pair in place when no token resolves', () => {
+      // No stylesheet — a fork mid-rename, or styles that failed to load.
+      // Degrading to the device preference beats naming a colour from a
+      // palette that is not on the page.
+      for (const scheme of ['light', 'dark'] as const) {
+        const meta = document.createElement('meta');
+        meta.setAttribute('name', 'theme-color');
+        meta.setAttribute('media', `(prefers-color-scheme: ${scheme})`);
+        meta.setAttribute('content', CHROME_COLORS[scheme]);
+        document.head.append(meta);
+        unhydrated.push(meta);
+      }
+
+      render(<ThemeToggle />);
+      fireEvent.click(toggle());
+
+      expect(chromeColors()).toEqual([CHROME_COLORS.light, CHROME_COLORS.dark]);
     });
   });
 });

--- a/src/lib/__tests__/theme.test.ts
+++ b/src/lib/__tests__/theme.test.ts
@@ -1,22 +1,76 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  applyThemeColor,
   DARK_SCHEME_QUERY,
   nextThemeChoice,
   readStoredThemeChoice,
+  renderedThemeColor,
   resolveTheme,
   storeThemeChoice,
+  syncThemeColor,
   THEME_ATTRIBUTE,
   THEME_CHOICE_ATTRIBUTE,
   THEME_CHOICES,
+  THEME_COLOR_TOKEN,
   THEME_STORAGE_KEY,
   type ThemeChoice,
+  type ThemeColors,
   themeInitScript,
 } from '../theme';
+import { readColorToken } from '../tokens';
+
+/**
+ * The real token values, so this cannot pass against a palette the site does
+ * not have. Which token the chrome takes is pinned in `theme-color.test.ts`.
+ */
+const CHROME_COLORS: ThemeColors = {
+  light: readColorToken(THEME_COLOR_TOKEN, 'light'),
+  dark: readColorToken(THEME_COLOR_TOKEN, 'dark'),
+};
 
 /** Runs the bootstrap the way a browser does: as a script against this DOM. */
 function runThemeInitScript(): void {
-  new Function(themeInitScript())();
+  new Function(themeInitScript(CHROME_COLORS))();
+}
+
+const injected: Element[] = [];
+
+/**
+ * The media-scoped pair the static export ships, as a browser parses it —
+ * both tags present, whatever the device happens to prefer.
+ */
+function addThemeColorMetas(): void {
+  for (const scheme of ['light', 'dark'] as const) {
+    const meta = document.createElement('meta');
+    meta.setAttribute('name', 'theme-color');
+    meta.setAttribute('media', `(prefers-color-scheme: ${scheme})`);
+    meta.setAttribute('content', CHROME_COLORS[scheme]);
+    document.head.append(meta);
+    injected.push(meta);
+  }
+}
+
+/**
+ * The shape of the real declarations: the token in `:root`, overridden under
+ * `[data-theme='dark']`. jsdom resolves custom properties through the cascade,
+ * so this exercises the same read the browser does. It is written out rather
+ * than loaded from `app/styles/` because the light values live in a Tailwind
+ * `@theme` block, which jsdom does not parse.
+ */
+function addTokenStylesheet(): void {
+  const style = document.createElement('style');
+  style.textContent =
+    `:root{${THEME_COLOR_TOKEN}:${CHROME_COLORS.light};}` +
+    `[${THEME_ATTRIBUTE}='dark']{${THEME_COLOR_TOKEN}:${CHROME_COLORS.dark};}`;
+  document.head.append(style);
+  injected.push(style);
+}
+
+function chromeColors(): string[] {
+  return [...document.querySelectorAll('meta[name="theme-color"]')].map(
+    (meta) => meta.getAttribute('content') ?? '',
+  );
 }
 
 function setPrefersDark(prefersDark: boolean): void {
@@ -71,7 +125,10 @@ describe('theme', () => {
     setPrefersDark(false);
   });
 
-  afterEach(clearRoot);
+  afterEach(() => {
+    clearRoot();
+    for (const node of injected.splice(0)) node.remove();
+  });
 
   describe('nextThemeChoice', () => {
     it('cycles system to light to dark and back', () => {
@@ -201,6 +258,105 @@ describe('theme', () => {
 
       expect(choiceAttribute()).toBe('system');
       expect(themeAttribute()).toBe('light');
+    });
+
+    it('paints the chrome from the stored choice, not from the device', () => {
+      // The bug: the meta tags are scoped by `prefers-color-scheme`, so a
+      // visitor reading in light mode on a dark device got a black address
+      // bar over a white page — and the reverse.
+      addThemeColorMetas();
+      setPrefersDark(true);
+      window.localStorage.setItem(THEME_STORAGE_KEY, 'light');
+
+      runThemeInitScript();
+
+      expect(themeAttribute()).toBe('light');
+      expect(chromeColors()).toEqual([
+        CHROME_COLORS.light,
+        CHROME_COLORS.light,
+      ]);
+    });
+
+    it('paints the chrome from the device while the choice is system', () => {
+      // Following the device is what `system` means, so the scoping is right
+      // here and the resolved value has to agree with it rather than fight it.
+      addThemeColorMetas();
+      setPrefersDark(true);
+
+      runThemeInitScript();
+
+      expect(themeAttribute()).toBe('dark');
+      expect(chromeColors()).toEqual([CHROME_COLORS.dark, CHROME_COLORS.dark]);
+    });
+
+    it('runs on a page with no theme-color tags at all', () => {
+      // A fork that drops the viewport export still gets its theme.
+      expect(runThemeInitScript).not.toThrow();
+      expect(themeAttribute()).toBe('light');
+    });
+  });
+
+  describe('applyThemeColor', () => {
+    it('points every tag at one colour, whatever each is scoped to', () => {
+      // Which tag the browser picks stops mattering once they agree, so this
+      // needs no opinion about `theme-color` precedence between them.
+      addThemeColorMetas();
+
+      applyThemeColor(document, CHROME_COLORS.dark);
+
+      expect(chromeColors()).toEqual([CHROME_COLORS.dark, CHROME_COLORS.dark]);
+    });
+
+    it('leaves the media-scoped pair alone rather than emptying it', () => {
+      // An empty `content` is skipped by the browser, which falls back to its
+      // own default chrome — strictly worse than the scoped pair already here.
+      addThemeColorMetas();
+
+      applyThemeColor(document, '');
+
+      expect(chromeColors()).toEqual([CHROME_COLORS.light, CHROME_COLORS.dark]);
+    });
+  });
+
+  describe('renderedThemeColor', () => {
+    it('reads the token the page is actually painted with', () => {
+      addTokenStylesheet();
+
+      document.documentElement.setAttribute(THEME_ATTRIBUTE, 'dark');
+      expect(renderedThemeColor(document)).toBe(CHROME_COLORS.dark);
+
+      document.documentElement.setAttribute(THEME_ATTRIBUTE, 'light');
+      expect(renderedThemeColor(document)).toBe(CHROME_COLORS.light);
+    });
+
+    it('reports nothing when the token has not resolved', () => {
+      expect(renderedThemeColor(document)).toBe('');
+    });
+  });
+
+  describe('syncThemeColor', () => {
+    it('follows data-theme, which is the only thing the styles follow', () => {
+      addTokenStylesheet();
+      addThemeColorMetas();
+
+      document.documentElement.setAttribute(THEME_ATTRIBUTE, 'dark');
+      syncThemeColor(document);
+      expect(chromeColors()).toEqual([CHROME_COLORS.dark, CHROME_COLORS.dark]);
+
+      document.documentElement.setAttribute(THEME_ATTRIBUTE, 'light');
+      syncThemeColor(document);
+      expect(chromeColors()).toEqual([
+        CHROME_COLORS.light,
+        CHROME_COLORS.light,
+      ]);
+    });
+
+    it('degrades to the media-scoped pair when no token resolves', () => {
+      addThemeColorMetas();
+
+      syncThemeColor(document);
+
+      expect(chromeColors()).toEqual([CHROME_COLORS.light, CHROME_COLORS.dark]);
     });
   });
 });

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -11,6 +11,10 @@
  *   render its own state — which is what forced it to wait for hydration and
  *   leave a 44x44 hole in the header.
  *
+ * The `theme-color` meta tags follow `data-theme` too, for the same reason
+ * every stylesheet does: an explicit choice is allowed to disagree with the
+ * device, and the browser chrome has to be the colour immediately under it.
+ *
  * The functions that touch `window` are browser-only by design; the module has
  * no `'use client'` marker so `app/layout.tsx` can build the bootstrap script
  * from the same constants the client uses.
@@ -26,6 +30,28 @@ export const THEME_STORAGE_KEY = 'theme';
 export const THEME_ATTRIBUTE = 'data-theme';
 export const THEME_CHOICE_ATTRIBUTE = 'data-theme-choice';
 export const DARK_SCHEME_QUERY = '(prefers-color-scheme: dark)';
+
+/**
+ * The token whose value the browser chrome is painted with: the page
+ * background the sticky header tints, not the raised surface.
+ */
+export const THEME_COLOR_TOKEN = '--color-bg-alt';
+
+/**
+ * Every `theme-color` meta, not the one that happens to match the device.
+ *
+ * `theme-color` has no `data-theme` selector, so the only lever from script is
+ * the `content` of the tags themselves. The static export ships the
+ * media-scoped pair from `app/layout.tsx` — that is the answer for a visitor
+ * with no JavaScript, and the only correct one available without it. Once
+ * script runs, the device preference stops being the question, so every tag is
+ * pointed at the rendered theme and it no longer matters which one the browser
+ * picks.
+ */
+export const THEME_COLOR_META_SELECTOR = 'meta[name="theme-color"]';
+
+/** The chrome colour for each theme, lifted out of the stylesheets at build. */
+export type ThemeColors = Readonly<Record<ResolvedTheme, string>>;
 
 /**
  * The order the single control cycles through. `system` is a real, reachable
@@ -94,13 +120,68 @@ export function storeThemeChoice(choice: ThemeChoice): void {
 }
 
 /**
+ * Point every `theme-color` meta at one colour.
+ *
+ * An empty colour is a no-op rather than an empty `content`: a tag with no
+ * usable value is skipped by the browser, which would drop back to its own
+ * default chrome instead of to the media-scoped value that is already there.
+ */
+export function applyThemeColor(doc: Document, color: string): void {
+  if (!color) return;
+
+  for (const meta of doc.querySelectorAll(THEME_COLOR_META_SELECTOR)) {
+    meta.setAttribute('content', color);
+  }
+}
+
+/**
+ * The colour the page is actually painted with, read back off `<html>`.
+ *
+ * Deliberately the computed token rather than a hex handed to the client: the
+ * cascade has already answered this question, so this cannot disagree with
+ * what is on screen the way a second copy of the palette could. Returns `''`
+ * when the stylesheet has not resolved — {@link applyThemeColor} then leaves
+ * the existing tags alone.
+ */
+export function renderedThemeColor(doc: Document): string {
+  const view = doc.defaultView;
+  if (!view) return '';
+
+  return view
+    .getComputedStyle(doc.documentElement)
+    .getPropertyValue(THEME_COLOR_TOKEN)
+    .trim();
+}
+
+/**
+ * Bring the browser chrome back in step with `<html data-theme>`.
+ *
+ * Call after `data-theme` settles, on every change: the attribute is what the
+ * visitor chose, and the device preference the meta tags are scoped by is not.
+ */
+export function syncThemeColor(doc: Document): void {
+  applyThemeColor(doc, renderedThemeColor(doc));
+}
+
+/**
  * The inline `<head>` script that stamps both attributes before first paint.
  *
  * Built from the constants above so the bootstrap and the React control cannot
  * drift apart. Each `window` access is guarded separately: a `localStorage`
  * that throws used to abort the whole function and ship a page with no
  * `data-theme` at all.
+ *
+ * It also settles the chrome colour, in the same pass and from the same
+ * resolved theme, because a returning visitor whose stored choice contradicts
+ * their device would otherwise have the address bar painted from the media
+ * query for the whole of the first paint. The colours are passed in rather
+ * than read here: they come from `readColorToken`, which reads the filesystem
+ * and must not reach the client bundle. They are embedded through
+ * `JSON.stringify` so a value can never break out of the string literal.
  */
-export function themeInitScript(): string {
-  return `(function(){var c='system';try{var s=window.localStorage.getItem('${THEME_STORAGE_KEY}');if(s==='light'||s==='dark'){c=s}}catch(e){}var r=document.documentElement;r.setAttribute('${THEME_CHOICE_ATTRIBUTE}',c);var t=c;if(c==='system'){t='light';try{if(window.matchMedia('${DARK_SCHEME_QUERY}').matches){t='dark'}}catch(e){}}r.setAttribute('${THEME_ATTRIBUTE}',t)})();`;
+export function themeInitScript(colors: ThemeColors): string {
+  const light = JSON.stringify(colors.light);
+  const dark = JSON.stringify(colors.dark);
+
+  return `(function(){var c='system';try{var s=window.localStorage.getItem('${THEME_STORAGE_KEY}');if(s==='light'||s==='dark'){c=s}}catch(e){}var r=document.documentElement;r.setAttribute('${THEME_CHOICE_ATTRIBUTE}',c);var t=c;if(c==='system'){t='light';try{if(window.matchMedia('${DARK_SCHEME_QUERY}').matches){t='dark'}}catch(e){}}r.setAttribute('${THEME_ATTRIBUTE}',t);var k=t==='dark'?${dark}:${light},m=document.querySelectorAll('${THEME_COLOR_META_SELECTOR}');for(var i=0;i<m.length;i++){m[i].setAttribute('content',k)}})();`;
 }


### PR DESCRIPTION
## The bug

`app/layout.tsx` declared `theme-color` as a media-scoped pair:

```
<meta name="theme-color" content="#f2f1ec" media="(prefers-color-scheme: light)">
<meta name="theme-color" content="#0d1015" media="(prefers-color-scheme: dark)">
```

That keys the browser chrome off the **device** preference. Nothing in this
project themes off the device preference — I checked: `prefers-color-scheme`
appears in exactly three places in `app/` and `src/`, and all three are this
meta pair, the `DARK_SCHEME_QUERY` constant, and a comment. Every stylesheet
rule keys off `[data-theme='dark']`, which the visitor can pin to either value
and which persists to `localStorage` across visits.

So for anyone whose stored choice disagrees with their OS, the Android address
bar and the Safari toolbar were painted the opposite of the page for the whole
visit: a white bar over a black page, or the reverse. The comment already in
the file said the value has to be "the colour immediately under it".

## The fix

`theme-color` has no `data-theme` selector, so the only lever is the tags'
`content`. Both readers of the theme now keep them in step with what is
actually painted:

- **`themeInitScript`** (`src/lib/theme.ts`) points every `theme-color` tag at
  the resolved theme in the same pass that stamps `data-theme`, using hexes
  read at build by `readColorToken`.
- **`ThemeToggle`**'s existing effect calls the new `syncThemeColor` after
  `data-theme` settles. It already re-runs on a choice change and on a device
  flip, which is what keeps `system` live.

The media-scoped pair stays exactly as it was. It is the no-JavaScript answer
and the only correct one available without reading `localStorage`, so with
scripting off the behaviour is unchanged.

All three control states:

| choice | chrome |
| --- | --- |
| `light` / `dark` | the chosen theme, overriding the device |
| `system` | the device, and it re-follows on an OS flip mid-visit |
| no JavaScript | the media-scoped pair, as before |

### The client does not carry a copy of the palette

`syncThemeColor` reads `--color-bg-alt` back out of the cascade with
`getComputedStyle(document.documentElement)`. The cascade has already answered
"what colour is this page", so the tag cannot name a colour the page is not
painted with — a second hardcoded copy could drift, and a hex passed down as a
prop could not reach the toggle without threading it through `Navigation`.

The bootstrap runs before the stylesheet is guaranteed to have resolved, so it
takes both hexes from `readColorToken` instead. If nothing resolves, the scoped
pair is left in place rather than emptied: an empty `content` is skipped by the
browser, which drops back to its own default chrome — strictly worse than the
device-scoped guess already sitting there.

Setting **every** tag rather than the one matching the device is deliberate.
It means this needs no opinion about `theme-color` precedence between the two,
and no tag is left behind carrying a stale value.

## One thing in the brief that was false

The brief (and the comment in `app/layout.tsx`) said the existing bootstrap
"already resolves the theme before first paint". It does not, and could not.
`<Script strategy="beforeInteractive">` in the App Router does not emit an
inline script — the export contained:

```
<script>(self.__next_s=self.__next_s||[]).push([0,{"children":"(function(){var c='system'…
```

and `node_modules/next/dist/client/app-bootstrap.js` runs that queue
(`loadScriptsInSequence(self.__next_s, …)`) after the client chunks have
loaded, before hydration. That is well after first paint, so both `data-theme`
and any chrome colour it set would have been late.

Since the acceptance criterion was first-paint correctness, and `app/layout.tsx`
is in scope, the bootstrap is now a plain parser-blocking inline `<script>`
with `dangerouslySetInnerHTML`. Verified in the export: `__next_s` no longer
appears anywhere in `out/index.html`, and the script body is inline at index
3716 — after the `theme-color` tags at index 1416, so the tags it queries are
already parsed when it runs. As a side effect this also closes the light flash
a dark-mode visitor got on every cold load.

## Tests

+17 (793 → 810).

- `src/lib/__tests__/theme.test.ts` — the bootstrap paints the chrome from a
  stored `light` choice on a device that prefers dark (the bug, exactly), from
  the device under `system`, and survives a page with no `theme-color` tags.
  Plus `applyThemeColor` / `renderedThemeColor` / `syncThemeColor`, including
  the two degradation paths.
- `src/components/__tests__/Template/ThemeToggle.test.tsx` — a real head (the
  scoped pair plus the token declarations `data-theme` switches between), then
  cycling the control: the chrome follows a chosen theme against the device,
  hands back on the way round to `system`, re-follows an OS flip, and over six
  presses never names a colour `data-theme` is not showing. jsdom resolves
  custom properties through the cascade, so this exercises the same read the
  browser does.
- `app/__tests__/theme-color.test.ts` — the emitted `viewport` pair for the
  no-JS case (unchanged), that the two colours actually differ so the scoping
  is not vacuous, and that the layout ships the bootstrap as a literal inline
  `<script>` with both hexes and no `__next_s`.

All colours in the tests come from `readColorToken`, so none of this can pass
against a palette the site does not have.

## Verification

- `npm run format`, `npx biome check .`, `npx tsc --noEmit` — clean
- `npx vitest run` — 810 pass (793 on the base)
- `npm run build` — clean; `npm run verify-export` 14 pages OK;
  `npm run measure-export` 7 budgets within limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
