### PR TITLE
test(scripts): cover the shared build-gate helpers

### DIFF
--- a/scripts/__tests__/html.test.ts
+++ b/scripts/__tests__/html.test.ts
@@ -1,0 +1,318 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  attribute,
+  canonicalValues,
+  decodeHtml,
+  elements,
+  metaValues,
+  tags,
+} from '../lib/html.mjs';
+
+/**
+ * `scripts/lib/html.mjs` reads the exported markup with regexes rather than a
+ * DOM, on purpose — the gates that use it run after the build with no DOM
+ * available, and a parser dependency would have no other use here. That trade
+ * only stays safe while its edges are stated, so this file pins both the
+ * behaviour the gates rely on and the limitations that come with it.
+ *
+ * The gates are `verify-export.mjs` (drafts, internal links, share metadata)
+ * and `measure-export.mjs` (the size budget), so a reader that quietly returns
+ * nothing turns a gate green rather than red. Every assertion below therefore
+ * distinguishes "absent" from "empty".
+ */
+
+describe('decodeHtml', () => {
+  it('decodes the named entities an exported attribute can carry', () => {
+    expect(
+      decodeHtml('&lt;p&gt;A &amp; B&#39;s &quot;quote&quot;&lt;/p&gt;'),
+    ).toBe(`<p>A & B's "quote"</p>`);
+    expect(decodeHtml('&apos;')).toBe("'");
+  });
+
+  it('decodes &amp; last, so an escaped entity survives as text', () => {
+    // `&amp;quot;` is the escaping of the literal text `&quot;`. Decoding
+    // `&amp;` first would turn it into `&quot;` and then into `"`, silently
+    // rewriting content the page renders as an entity reference.
+    expect(decodeHtml('&amp;quot;')).toBe('&quot;');
+    expect(decodeHtml('&amp;amp;')).toBe('&amp;');
+  });
+
+  it('decodes numeric references in either base and either case', () => {
+    expect(decodeHtml('&#x2F;')).toBe('/');
+    expect(decodeHtml('&#X2F;')).toBe('/');
+    expect(decodeHtml('&#8212;')).toBe('—');
+  });
+
+  it('decodes references above the basic multilingual plane', () => {
+    // Code points, not code units: an emoji in a share description is one
+    // reference well past 0xFFFF.
+    expect(decodeHtml('&#128512;')).toBe('😀');
+    expect(decodeHtml('&#x1f600;')).toBe('😀');
+  });
+
+  it('leaves an unrecognised entity exactly as it found it', () => {
+    expect(decodeHtml('a&nbsp;b')).toBe('a&nbsp;b');
+  });
+});
+
+describe('tags', () => {
+  it('returns opening tags only', () => {
+    expect(tags('<p>text</p><p>more</p>', 'p')).toEqual(['<p>', '<p>']);
+  });
+
+  it('returns every element when no name is given', () => {
+    // Names carry digits and hyphens (`h1`, a custom element), so the default
+    // pattern has to be more than a run of letters.
+    expect(
+      tags(
+        '<div class="a"><h1>t</h1><a href="x">y</a></div><my-el></my-el><br/>',
+      ),
+    ).toEqual(['<div class="a">', '<h1>', '<a href="x">', '<my-el>', '<br/>']);
+  });
+
+  it('matches element names case-insensitively', () => {
+    expect(tags('<META charset="utf-8">', 'meta')).toEqual([
+      '<META charset="utf-8">',
+    ]);
+  });
+
+  it('requires a whole element name, not a prefix of a longer one', () => {
+    // Without the word boundary, asking for `<link>` would also return
+    // `<linkgroup>` and the gate would read attributes off the wrong element.
+    expect(tags('<metadata content="x"><meta content="y">', 'meta')).toEqual([
+      '<meta content="y">',
+    ]);
+  });
+
+  it('returns a self-closing tag whole', () => {
+    expect(tags('<img src="a.png" alt=""/>', 'img')).toEqual([
+      '<img src="a.png" alt=""/>',
+    ]);
+  });
+
+  it('keeps a tag whole when an escaped angle bracket is in a value', () => {
+    // This is the case that occurs in practice: React escapes `>` in attribute
+    // values, so what reaches the gate is `&gt;`.
+    const tag = tags('<meta name="description" content="a &gt; b">', 'meta');
+
+    expect(tag).toEqual(['<meta name="description" content="a &gt; b">']);
+    expect(attribute(tag[0], 'content')).toBe('a > b');
+  });
+});
+
+describe('attribute', () => {
+  it('reads a double-quoted value', () => {
+    expect(attribute('<meta content="hello">', 'content')).toBe('hello');
+  });
+
+  it('reads a single-quoted value, including one holding a double quote', () => {
+    expect(attribute("<meta content='hello'>", 'content')).toBe('hello');
+    expect(attribute(`<meta content='say "hi"'>`, 'content')).toBe('say "hi"');
+  });
+
+  it('reads an unquoted value, stopping at whitespace or the tag end', () => {
+    expect(attribute('<meta charset=utf-8>', 'charset')).toBe('utf-8');
+    expect(attribute('<meta charset=utf-8 name="x">', 'charset')).toBe('utf-8');
+  });
+
+  it('tolerates whitespace around the equals sign', () => {
+    expect(attribute('<meta content = "hello">', 'content')).toBe('hello');
+  });
+
+  it('decodes entities in the value', () => {
+    expect(
+      attribute('<meta content="Tom &amp; Jerry &#39;96">', 'content'),
+    ).toBe("Tom & Jerry '96");
+  });
+
+  it('matches the attribute name case-insensitively', () => {
+    expect(attribute('<META CONTENT="hello">', 'content')).toBe('hello');
+  });
+
+  it('returns an empty value as the empty string, not as absent', () => {
+    // `og:image:alt=""` is a share card with no alt text, which is a failure
+    // the gate must see. Collapsing it to `undefined` would read as "this page
+    // has no alt attribute" and take a different branch.
+    expect(attribute('<meta content="">', 'content')).toBe('');
+    expect(attribute('<meta content="">', 'content')).not.toBeUndefined();
+  });
+
+  it('returns undefined for an attribute that is not there', () => {
+    expect(attribute('<meta name="x">', 'content')).toBeUndefined();
+    expect(attribute('<meta>', 'content')).toBeUndefined();
+  });
+
+  it('requires the name to start at an attribute boundary', () => {
+    // `data-content` is not `content`; matching inside a longer name would let
+    // a framework data attribute impersonate the one being checked.
+    expect(attribute('<meta data-content="x">', 'content')).toBeUndefined();
+  });
+
+  it('is not fooled by an attribute whose name merely starts the same', () => {
+    expect(
+      attribute('<meta contentx="wrong" content="right">', 'content'),
+    ).toBe('right');
+  });
+
+  it('does not swallow the slash of a self-closing tag from a quoted value', () => {
+    expect(attribute('<meta content="hello"/>', 'content')).toBe('hello');
+  });
+});
+
+describe('metaValues', () => {
+  const html = `
+    <meta charset="utf-8">
+    <meta property="og:image" content="first.png">
+    <meta property="OG:IMAGE" content="second.png">
+    <meta property="og:image">
+    <meta property="og:image:alt" content="ignored">
+    <meta name="og:image" content="wrong attribute">
+  `;
+
+  it('returns every matching value in document order', () => {
+    // Order and multiplicity both matter: a page carrying two canonical share
+    // images is exactly what the gate is looking for.
+    expect(metaValues(html, 'property', 'og:image')).toEqual([
+      'first.png',
+      'second.png',
+    ]);
+  });
+
+  it('matches the key value case-insensitively', () => {
+    expect(
+      metaValues(
+        '<meta name="TWITTER:CARD" content="summary">',
+        'name',
+        'twitter:card',
+      ),
+    ).toEqual(['summary']);
+  });
+
+  it('compares against a lowercase expectation, so callers must pass one', () => {
+    expect(metaValues(html, 'property', 'OG:IMAGE')).toEqual([]);
+  });
+
+  it('drops a matching meta that carries no content attribute', () => {
+    expect(metaValues('<meta name="robots">', 'name', 'robots')).toEqual([]);
+  });
+
+  it('keeps a matching meta whose content is empty', () => {
+    expect(
+      metaValues('<meta name="robots" content="">', 'name', 'robots'),
+    ).toEqual(['']);
+  });
+
+  it('ignores meta tags that do not carry the key attribute at all', () => {
+    expect(metaValues(html, 'property', 'og:title')).toEqual([]);
+    expect(metaValues('', 'property', 'og:title')).toEqual([]);
+  });
+});
+
+describe('canonicalValues', () => {
+  it('returns the href of a canonical link', () => {
+    expect(canonicalValues('<link rel="canonical" href="https://x/">')).toEqual(
+      ['https://x/'],
+    );
+  });
+
+  it('reads rel as a token list and matches case-insensitively', () => {
+    expect(
+      canonicalValues('<link rel="alternate CANONICAL" href="https://x/">'),
+    ).toEqual(['https://x/']);
+  });
+
+  it('does not match a rel that merely contains the word', () => {
+    expect(
+      canonicalValues('<link rel="canonicalish" href="https://x/">'),
+    ).toEqual([]);
+  });
+
+  it('returns every canonical, so a page carrying two is visible', () => {
+    expect(
+      canonicalValues(
+        '<link rel="canonical" href="a"><link rel="stylesheet" href="s.css"><link rel="canonical" href="b">',
+      ),
+    ).toEqual(['a', 'b']);
+  });
+
+  it('skips links with no rel and canonical links with no href', () => {
+    expect(canonicalValues('<link href="a">')).toEqual([]);
+    expect(canonicalValues('<link rel="canonical">')).toEqual([]);
+  });
+});
+
+describe('elements', () => {
+  it('returns whole elements including their markup', () => {
+    expect(elements('<p>x</p><style>a{b:c}</style>', 'style')).toEqual([
+      '<style>a{b:c}</style>',
+    ]);
+  });
+
+  it('does not merge two siblings into one match', () => {
+    // A greedy match would weigh everything between the first opening tag and
+    // the last closing one, which for inline styles is most of the document.
+    expect(
+      elements('<style>a</style><p>x</p><style>b</style>', 'style'),
+    ).toEqual(['<style>a</style>', '<style>b</style>']);
+  });
+
+  it('spans newlines', () => {
+    expect(elements('<style>\na {\n  b: c;\n}\n</style>', 'style')).toEqual([
+      '<style>\na {\n  b: c;\n}\n</style>',
+    ]);
+  });
+
+  it('keeps the attributes on the opening tag', () => {
+    expect(
+      elements('<svg class="icon" viewBox="0 0 1 1"><path/></svg>', 'svg'),
+    ).toEqual(['<svg class="icon" viewBox="0 0 1 1"><path/></svg>']);
+  });
+
+  it('matches either case and tolerates space in the closing tag', () => {
+    expect(elements('<STYLE>a</StYlE >', 'style')).toEqual([
+      '<STYLE>a</StYlE >',
+    ]);
+  });
+
+  it('returns nothing for an unclosed element', () => {
+    expect(elements('<style>a', 'style')).toEqual([]);
+  });
+});
+
+/**
+ * These are not desirable behaviours. They are the price of reading markup
+ * with regexes, and they are pinned so that a change to them is a deliberate
+ * one rather than a surprise — and so that a future reader can tell what this
+ * module is not able to do without having to rediscover it.
+ */
+describe('documented limitations', () => {
+  it('truncates an opening tag at a raw > inside a quoted value', () => {
+    // Safe only because React escapes `>` as `&gt;` in attribute values, which
+    // is what the exported pages actually contain (see the `tags` case above).
+    // Hand-written markup in `public/` would not be covered.
+    const [tag] = tags('<meta name="x" content="a > b">', 'meta');
+
+    expect(tag).toBe('<meta name="x" content="a >');
+    expect(attribute(tag, 'content')).not.toBe('a > b');
+  });
+
+  it('sees tags inside HTML comments', () => {
+    expect(
+      tags('<!-- <meta name="robots" content="noindex"> -->', 'meta'),
+    ).toEqual(['<meta name="robots" content="noindex">']);
+  });
+
+  it('includes the closing slash in an unquoted value on a self-closing tag', () => {
+    expect(attribute('<meta content=hello/>', 'content')).toBe('hello/');
+  });
+
+  it('truncates an element that nests inside itself', () => {
+    // `elements` is for inline `<svg>` icons and inline `<style>`/`<script>`
+    // bodies, none of which nest. A nested `<svg>` would be under-weighed by
+    // the size budget rather than reported.
+    expect(elements('<svg>a<svg>b</svg></svg>', 'svg')).toEqual([
+      '<svg>a<svg>b</svg>',
+    ]);
+  });
+});

--- a/scripts/__tests__/site.test.ts
+++ b/scripts/__tests__/site.test.ts
@@ -1,0 +1,368 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, sep } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { exportLayout, readSiteConfig, toUrlPath } from '../lib/site.mjs';
+
+/**
+ * `scripts/lib/site.mjs` is the single derivation of the exported site's URL
+ * shape, and both build gates (`verify-export.mjs`, `measure-export.mjs`) map
+ * URLs back to files through it. Almost all of it is inert on this repository,
+ * whose `homepage` has no base path — the branches only carry weight in a
+ * repository-site fork publishing under `/repo/`, which is precisely where
+ * nobody is watching. So every case below is stated for both base-path shapes.
+ */
+
+const fixtureRoots: string[] = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  while (fixtureRoots.length > 0) {
+    rmSync(fixtureRoots.pop() as string, { recursive: true, force: true });
+  }
+});
+
+function fixtureRoot(packageJson: unknown, { write = true } = {}) {
+  const root = mkdtempSync(join(tmpdir(), 'site-config-'));
+  fixtureRoots.push(root);
+  if (write) {
+    writeFileSync(
+      join(root, 'package.json'),
+      typeof packageJson === 'string'
+        ? packageJson
+        : JSON.stringify(packageJson),
+    );
+  }
+  return root;
+}
+
+/**
+ * `readSiteConfig` exits rather than throwing, because every caller is a build
+ * gate. Replacing the exit with a throw is what lets a test observe the
+ * rejection instead of taking the test runner down with it.
+ */
+function captureExit() {
+  const errors: string[] = [];
+  vi.spyOn(console, 'error').mockImplementation((message: string) => {
+    errors.push(message);
+  });
+  vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+    throw new Error(`process.exit(${code})`);
+  }) as never);
+  return errors;
+}
+
+function expectRejected(homepage: unknown) {
+  const errors = captureExit();
+  const root = fixtureRoot(
+    homepage === undefined ? { name: 'fixture' } : { homepage },
+  );
+  expect(() => readSiteConfig(root, 'gate')).toThrow('process.exit(1)');
+  return errors;
+}
+
+describe('readSiteConfig', () => {
+  it.each([
+    ['a user site', 'https://user.github.io/', 'https://user.github.io', ''],
+    [
+      'a repository site',
+      'https://user.github.io/repo/',
+      'https://user.github.io',
+      '/repo',
+    ],
+    ['a custom domain', 'https://example.com/', 'https://example.com', ''],
+    [
+      'a nested base path',
+      'https://example.com/a/b/',
+      'https://example.com',
+      '/a/b',
+    ],
+  ])(
+    'derives the origin and base path from %s',
+    (_, homepage, origin, base) => {
+      const root = fixtureRoot({ homepage });
+
+      expect(readSiteConfig(root, 'gate')).toEqual({ origin, basePath: base });
+    },
+  );
+
+  it('keeps the port in the origin and drops credentials, if any', () => {
+    const root = fixtureRoot({ homepage: 'https://example.com:8443/repo/' });
+
+    expect(readSiteConfig(root, 'gate')).toEqual({
+      origin: 'https://example.com:8443',
+      basePath: '/repo',
+    });
+  });
+
+  it('strips the base path trailing slash, however many there are', () => {
+    // `/repo/` is the shape a fork writes; the base path has to be the prefix
+    // that concatenates with a leading-slash route, so it cannot keep one.
+    const root = fixtureRoot({ homepage: 'https://example.com/repo//' });
+
+    expect(readSiteConfig(root, 'gate').basePath).toBe('/repo');
+  });
+
+  it('accepts a bare origin, which is already a trailing-slash URL', () => {
+    // `new URL` normalises the empty path to `/`, so this is a user site with
+    // no base path rather than a rejection.
+    const root = fixtureRoot({ homepage: 'https://user.github.io' });
+
+    expect(readSiteConfig(root, 'gate')).toEqual({
+      origin: 'https://user.github.io',
+      basePath: '',
+    });
+  });
+
+  it('rejects a base path with no trailing slash', () => {
+    // Not pedantry: `https://user.github.io/repo` would make the canonical URL
+    // of the home page disagree with the exported `/repo/index.html`.
+    const errors = expectRejected('https://user.github.io/repo');
+
+    expect(errors[0]).toContain('trailing slash');
+  });
+
+  it.each([
+    ['plain HTTP', 'http://example.com/'],
+    ['a query string', 'https://example.com/?utm=1'],
+    ['a fragment', 'https://example.com/#top'],
+    ['a protocol-relative URL', '//example.com/'],
+    ['a relative path', '/repo/'],
+    ['an empty string', ''],
+  ])('rejects %s', (_, homepage) => {
+    expectRejected(homepage);
+  });
+
+  it('rejects a package.json with no homepage at all', () => {
+    expectRejected(undefined);
+  });
+
+  it('rejects a package.json that is not readable or not JSON', () => {
+    const missingErrors = captureExit();
+    const missingRoot = fixtureRoot(null, { write: false });
+    expect(() => readSiteConfig(missingRoot, 'gate')).toThrow(
+      'process.exit(1)',
+    );
+    expect(missingErrors[0]).toContain('gate:');
+
+    vi.restoreAllMocks();
+
+    const malformedErrors = captureExit();
+    const malformedRoot = fixtureRoot('{ "homepage": ');
+    expect(() => readSiteConfig(malformedRoot, 'gate')).toThrow(
+      'process.exit(1)',
+    );
+    expect(malformedErrors[0]).toContain('gate:');
+  });
+
+  it('prefixes the failure with the caller label so CI logs name the gate', () => {
+    const errors = captureExit();
+    const root = fixtureRoot({ homepage: 'http://example.com/' });
+
+    expect(() => readSiteConfig(root, 'measure-export')).toThrow(
+      'process.exit(1)',
+    );
+    expect(errors[0]).toMatch(
+      /^measure-export: cannot read the canonical site URL from package\.json: /,
+    );
+  });
+
+  it("accepts this repository's own homepage", () => {
+    // The gates read the real `package.json` at build time. A homepage edited
+    // into a shape this rejects fails the build rather than the test suite,
+    // which is a slower and less obvious way to find out.
+    const homepage = JSON.parse(
+      readFileSync(join(process.cwd(), 'package.json'), 'utf8'),
+    ).homepage as string;
+    const { origin, basePath } = readSiteConfig(process.cwd(), 'gate');
+
+    expect(`${origin}${basePath}/`).toBe(homepage);
+  });
+});
+
+describe('toUrlPath', () => {
+  it('joins platform path segments with forward slashes', () => {
+    expect(toUrlPath(['writing', 'a-post', 'index.html'].join(sep))).toBe(
+      'writing/a-post/index.html',
+    );
+  });
+
+  it('leaves a single segment alone', () => {
+    expect(toUrlPath('index.html')).toBe('index.html');
+  });
+});
+
+describe.each([
+  ['without a base path', ''],
+  ['under a repository base path', '/repo'],
+])('exportLayout %s', (_, basePath) => {
+  const origin = 'https://example.com';
+
+  function layout() {
+    const outDir = mkdtempSync(join(tmpdir(), 'site-export-'));
+    fixtureRoots.push(outDir);
+    return { outDir, ...exportLayout({ outDir, origin, basePath }) };
+  }
+
+  const ROUTES = ['/', '/about/', '/writing/a-post/', '/feed.xml'];
+
+  it('exposes the configuration it was built with', () => {
+    const { origin: exposed, basePath: exposedBase } = layout();
+
+    expect(exposed).toBe(origin);
+    expect(exposedBase).toBe(basePath);
+  });
+
+  it('prefixes a route with the base path to get a public path', () => {
+    const { publicPathForRoute } = layout();
+
+    expect(publicPathForRoute('/')).toBe(`${basePath}/`);
+    expect(publicPathForRoute('/about/')).toBe(`${basePath}/about/`);
+  });
+
+  it('builds absolute site URLs from routes', () => {
+    const { siteUrlForRoute } = layout();
+
+    expect(siteUrlForRoute('/about/')).toBe(`${origin}${basePath}/about/`);
+    expect(siteUrlForRoute('/')).toBe(`${origin}${basePath}/`);
+  });
+
+  it('round-trips every route through its public path', () => {
+    const { publicPathForRoute, routeForPublicPath } = layout();
+
+    for (const route of ROUTES) {
+      expect(routeForPublicPath(publicPathForRoute(route))).toBe(route);
+    }
+  });
+
+  it('maps exported HTML file paths back to routes', () => {
+    const { routeForHtml } = layout();
+
+    // Routes, not public paths: callers prefix them with the base path
+    // themselves, and doing it here would double the prefix.
+    expect(routeForHtml('index.html')).toBe('/');
+    expect(routeForHtml('about/index.html')).toBe('/about/');
+    expect(routeForHtml('writing/a-post/index.html')).toBe('/writing/a-post/');
+    expect(routeForHtml('404.html')).toBe('/404.html');
+  });
+
+  it('resolves a public path to the file backing it', () => {
+    const { outDir, exportFileFor, publicPathForRoute } = layout();
+    writeFileSync(join(outDir, 'feed.xml'), '<rss/>');
+    mkdirSync(join(outDir, 'about'));
+    writeFileSync(join(outDir, 'about', 'index.html'), '<html></html>');
+
+    expect(exportFileFor(publicPathForRoute('/feed.xml'))).toBe(
+      join(outDir, 'feed.xml'),
+    );
+    expect(exportFileFor(publicPathForRoute('/about/index.html'))).toBe(
+      join(outDir, 'about', 'index.html'),
+    );
+  });
+
+  it('decodes a percent-encoded public path before resolving it', () => {
+    const { outDir, exportFileFor, publicPathForRoute } = layout();
+    writeFileSync(join(outDir, 'a file.png'), 'png');
+
+    expect(exportFileFor(publicPathForRoute('/a%20file.png'))).toBe(
+      join(outDir, 'a file.png'),
+    );
+  });
+
+  it('returns undefined for an undecodable public path rather than throwing', () => {
+    const { exportFileFor, publicPathForRoute } = layout();
+
+    expect(exportFileFor(publicPathForRoute('/%zz'))).toBeUndefined();
+  });
+
+  it('returns undefined for a directory, so a link to one is not "exported"', () => {
+    const { outDir, exportFileFor, publicPathForRoute } = layout();
+    mkdirSync(join(outDir, 'about'));
+
+    expect(exportFileFor(publicPathForRoute('/about'))).toBeUndefined();
+    expect(exportFileFor(publicPathForRoute('/'))).toBeUndefined();
+  });
+
+  it('returns undefined for a file that is not in the export', () => {
+    const { exportFileFor, publicPathForRoute } = layout();
+
+    expect(exportFileFor(publicPathForRoute('/missing.html'))).toBeUndefined();
+  });
+
+  it('refuses to escape the export directory', () => {
+    const { outDir, exportFileFor, publicPathForRoute } = layout();
+    // A real file, so it is the traversal guard rejecting this and not merely
+    // the existence check.
+    const sibling = `${outDir}side.txt`;
+    writeFileSync(sibling, 'secret');
+    fixtureRoots.push(sibling);
+
+    // `..` escapes; the sibling also shares a string prefix with `outDir`,
+    // which is why the guard has to compare against `outDir + sep`.
+    const leaf = sibling.split(sep).pop() as string;
+    expect(exportFileFor(publicPathForRoute(`/../${leaf}`))).toBeUndefined();
+    expect(
+      exportFileFor(publicPathForRoute(`/%2e%2e/${leaf}`)),
+    ).toBeUndefined();
+  });
+});
+
+describe('exportLayout under a repository base path', () => {
+  const origin = 'https://example.com';
+  const basePath = '/repo';
+
+  it('rejects a public path outside the base path', () => {
+    const { routeForPublicPath } = exportLayout({
+      outDir: '/nowhere',
+      origin,
+      basePath,
+    });
+
+    expect(routeForPublicPath('/about/')).toBeUndefined();
+    expect(routeForPublicPath('/')).toBeUndefined();
+  });
+
+  it('treats the base path as a whole path segment', () => {
+    // `/repository/` starts with `/repo` as a string but is a different site.
+    const { routeForPublicPath } = exportLayout({
+      outDir: '/nowhere',
+      origin,
+      basePath,
+    });
+
+    expect(routeForPublicPath('/repository/')).toBeUndefined();
+    expect(routeForPublicPath('/repo')).toBeUndefined();
+    expect(routeForPublicPath('/repo/')).toBe('/');
+    expect(routeForPublicPath('/repo/about/')).toBe('/about/');
+  });
+
+  it('does not resolve a file addressed without the base path', () => {
+    // The export is served under `/repo/`, so `/feed.xml` is a link to some
+    // other site that happens to share the origin — not to this file.
+    const outDir = mkdtempSync(join(tmpdir(), 'site-export-'));
+    fixtureRoots.push(outDir);
+    writeFileSync(join(outDir, 'feed.xml'), '<rss/>');
+    const { exportFileFor } = exportLayout({ outDir, origin, basePath });
+
+    expect(exportFileFor('/feed.xml')).toBeUndefined();
+    expect(exportFileFor('/repo/feed.xml')).toBe(join(outDir, 'feed.xml'));
+  });
+
+  it('passes any path through untouched when there is no base path', () => {
+    const { routeForPublicPath } = exportLayout({
+      outDir: '/nowhere',
+      origin,
+      basePath: '',
+    });
+
+    expect(routeForPublicPath('/about/')).toBe('/about/');
+    expect(routeForPublicPath('/repo/about/')).toBe('/repo/about/');
+  });
+});


### PR DESCRIPTION
`scripts/lib/site.mjs` and `scripts/lib/html.mjs` are the shared readers behind
`verify-export.mjs` and `measure-export.mjs` — the gates that stop draft leaks,
broken internal links, missing share metadata, and size regressions from
shipping. Neither had a test file. They were exercised only indirectly, through
fixtures that happen to have no base path and no awkward markup.

89 new tests, no behaviour change to either module.

## The number

Before writing anything I ran 40 single-behaviour mutations of the two modules
against the existing suite (`verify-export.test.ts` and `measure-export.test.ts`
are the only tests that reach them). **32 of the 40 survived** — you could make
the change and every test still passed. All 40 now fail a named test.

Everything that survived the old suite:

| `site.mjs` | `html.mjs` |
| --- | --- |
| base path strips only one trailing slash | `&amp;` decoded first instead of last |
| HTTPS / trailing slash / query / fragment no longer required | `fromCodePoint` → `fromCharCode` |
| failure message loses the caller label | numeric-entity regex loses its `i` flag |
| base path matched as a string prefix, not a segment | `tags()` loses its element-name word boundary |
| `exportFileFor` loses the directory-escape guard | `tags()` / `attribute()` / `elements()` become case-sensitive |
| escape guard compares without the path separator | `attribute()` loses its attribute-name boundary |
| `exportFileFor` accepts a directory | `attribute()` `??` → `\|\|`, so an empty value reads as absent |
| `exportFileFor` stops decoding, or stops catching a bad `%` escape | `metaValues` / `canonicalValues` stop dropping absent values |
| `exportFileFor` stops rejecting paths outside the base path | `canonicalValues` matches `rel` as a substring |
| | `elements()` becomes greedy, or stops spanning newlines |

The eight the old suite did catch, for completeness: `publicPathForRoute` and
`siteUrlForRoute` dropping the base path, both `routeForHtml` branches, `origin`
→ `href`, the base path keeping its trailing slash, `toUrlPath`'s join
separator, and `attribute()` throwing instead of returning `undefined`.

## Method

Every test was written by making the mutation first, confirming the test fails,
then reverting and confirming it passes. A test that cannot fail is worse than
no test, because it buys false confidence.

Worth recording: **the harness itself was wrong on the first pass.** It ran
`vitest --reporter=basic`, which does not exist in Vitest 4, so every run exited
non-zero and every mutant looked killed — including mutants I later confirmed
survive untouched. The 40/40 only means anything because the fixed harness
reports *which named test* failed, and each time it is the test written for that
mutant.

## Coverage, per the brief

`site.mjs` — user-site homepage, repository-site homepage, custom domain, nested
base path, port-carrying origin, homepage with and without a trailing slash (a
bare origin is accepted because `new URL` normalises it; `/repo` without one is
rejected), collapsed repeated slashes, missing / empty / `http:` / query /
fragment / relative homepage, unreadable and malformed `package.json`, the
caller label in the failure, this repository's own homepage, and
`routeForPublicPath(publicPathForRoute(r)) === r` over four routes for both
base-path shapes. `exportLayout` is a `describe.each` over both shapes, so
`exportFileFor`'s percent-decoding, directory rejection, traversal guard and
`outDir + sep` boundary are each asserted twice.

`html.mjs` — single vs double vs unquoted values, self-closing tags, duplicated
meta names, missing attributes returning `undefined` rather than throwing, empty
values returning `''` rather than `undefined`, and case-insensitivity everywhere
the readers claim it (element name, attribute name, meta key value, `rel` token,
numeric entity, closing tag).

## No bug found, but four limitations pinned

Behaviour is unchanged. The regex readers do have edges, and they now sit in a
`documented limitations` block that states each as a cost of not using a parser
rather than something nobody noticed:

- an opening tag is truncated at a **raw `>` inside a quoted value**. Safe only
  because React escapes `>` as `&gt;` in attribute values — the `&gt;` path is
  tested and works — so hand-written markup in `public/` would not be covered.
- `tags()` **sees tags inside HTML comments**, so a required meta tag present
  only in a comment would satisfy the metadata gate. Next emits no comments in
  `<head>`, so nothing reaches this today.
- an unquoted value on a self-closing tag keeps the slash (`content=hello/>` →
  `hello/`).
- `elements()` truncates an element nested inside itself, exactly as its doc
  comment says; a nested inline `<svg>` would be under-weighed by the budget
  rather than reported.

Fixing any of these means a quote-aware reader on a load-bearing gate, which is
a behaviour change and out of scope here.

## Verification

`npm run format`, `npx biome check .`, `npx tsc --noEmit` all clean.
`npx vitest run`: **882 passed** (793 on the base branch + 89 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
