### PR TITLE
fix(test): make the icon manifest assertion platform-independent

### DIFF
--- a/scripts/__tests__/generate-icons.test.ts
+++ b/scripts/__tests__/generate-icons.test.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, posix } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import profile from '@/data/profile.json';
@@ -97,6 +97,20 @@ describe('generated icon set', () => {
   });
 
   /**
+   * The ledger is committed, so its keys have to mean the same thing on every
+   * platform `npm run icons` might be run from. They are forward-slash literals
+   * in the generator today; deriving one with `join` instead would write
+   * backslashed keys from a Windows regeneration, and the committed file would
+   * then resolve to nothing everywhere else.
+   */
+  it('keys the ledger by forward-slash path on every platform', () => {
+    for (const path of Object.keys(meta.files)) {
+      expect(path).not.toContain('\\');
+      expect(path).toBe(posix.normalize(path));
+    }
+  });
+
+  /**
    * Next reads these dimensions off the files themselves and puts them in the
    * `sizes` attribute of the `<link>` tags it emits, so the wrong size here is
    * a wrong promise in every page's `<head>`.
@@ -169,6 +183,13 @@ describe('generated web app manifest', () => {
    * prefix. A leading slash — which is what the deleted manifest used — breaks
    * that. The paths also have to name files that exist, since the deleted
    * manifest's did not once the art moved.
+   *
+   * Both sides of the containment check are url-shaped strings, so the key is
+   * built with `posix.join` rather than `join`. `join` is `win32.join` on
+   * Windows and normalises the separators to backslashes, which would miss a
+   * ledger key that is correct — a red test against a green manifest, on the
+   * one platform this repository's contributors are least likely to be able to
+   * reproduce.
    */
   it('points every icon at a committed file by relative path', () => {
     expect(manifest.icons.length).toBeGreaterThan(0);
@@ -176,7 +197,7 @@ describe('generated web app manifest', () => {
     for (const icon of manifest.icons) {
       expect(icon.src.startsWith('/')).toBe(false);
       expect(icon.src.startsWith('http')).toBe(false);
-      expect(Object.keys(meta.files)).toContain(join('public', icon.src));
+      expect(Object.keys(meta.files)).toContain(posix.join('public', icon.src));
     }
   });
 


### PR DESCRIPTION
Implements Copilot's review comment on #944 (`scripts/__tests__/generate-icons.test.ts`, line 179). The claim checked out, so it is implemented rather than refuted.

## The defect

`scripts/icons.meta.json` is written by `generate-icons.mjs` from the literal keys of its `outputs` object, so `meta.files` is keyed with forward slashes:

```
public/images/icons/icon-192.png
```

`app/manifest.json` carries `src: 'images/icons/icon-192.png'` — a url path, deliberately relative so a repository-site fork resolves it under its own basePath. The test bridged the two with `path.join`, which is `path.win32.join` on Windows:

```
$ node -p "require('node:path').win32.join('public','images/icons/icon-192.png')"
public\images\icons\icon-192.png
```

That string is in no ledger key, so the assertion goes red against a manifest and a ledger that are both correct. `path.posix.join` returns `public/images/icons/icon-192.png`, which is there. Verified by running both and checking `Object.keys(meta.files).includes(...)` for each — `false` for the win32 form, `true` for the posix one.

Worth being precise about the blast radius, because the framing that reached me overstated it: the `windows-latest` matrix leg in `.github/workflows/node.js.yml` is the **build** job, which runs `npm run build`, `verify-export`, and `measure-export`. Vitest runs only in the `test` job, on `ubuntu-latest`. So this is not a red CI leg today — it is a red `npm test` for anyone developing on Windows, which is the harder failure to diagnose because nobody else can reproduce it.

## Also added

One test pinning the invariant the containment check now depends on: the committed ledger's keys stay forward-slash. The keys are hardcoded literals today, but `npm run icons` is a command a contributor runs, and deriving those keys with `join` would let a Windows regeneration commit a ledger that resolves to nothing anywhere else.

## Scan of the neighbouring script tests

Checked every `join` in `scripts/__tests__/` for the same shape — an OS-specific path compared against a forward-slash manifest key or url path. This was the only one.

- `site.test.ts:192` runs the comparison in the correct direction: it builds a platform path with `sep` and feeds it to `toUrlPath`, which is exactly what that helper is for.
- `site.test.ts:355`, `measure-export.test.ts`, `verify-export.test.ts`, `drafts.test.ts`, and `og-inputs.test.ts` use `join` only to build filesystem paths for `readFileSync` / `existsSync` / `mkdtempSync`, where the platform separator is the right answer.
- `og-inputs.test.ts:67` compares `card.path` against `postCardPath()`, and that helper builds its string with a template literal (`${POST_CARD_DIRECTORY}/${slug}.png`), never `join` — already platform-independent.
- `measure-export.test.ts` asserts against routes that came out of `toUrlPath`, and against `'scripts/budget.json'` message strings that are literals in `measure-export.mjs`, not composed paths.

## Verification

`npm run format` clean · `npx biome check .` clean (224 files) · `npx tsc --noEmit` exit 0 · `npx vitest run` 83 files, 940 tests passing — 939 on the base plus the one added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
