### PR TITLE
fix(docs): correct three comments that describe behaviour the code does not have

### DIFF
--- a/src/components/Template/ThemeToggle.tsx
+++ b/src/components/Template/ThemeToggle.tsx
@@ -61,7 +61,12 @@ function labelFor(choice: ThemeChoice): string {
 }
 
 /**
- * Cycles light → dark → system, where `system` follows the device live.
+ * Cycles system → light → dark → system, where `system` follows the device live.
+ *
+ * That order is `nextThemeChoice`'s, not a copy of it: both the labels and the
+ * rendered states below come out of `src/lib/theme.ts`, so this control cannot
+ * end up describing an order it does not perform. `system` is the state a
+ * visitor who has never chosen starts in, and the one they can get back to.
  *
  * The rendered markup is deliberately identical for all three states: every
  * state is present, and CSS shows the one matching `data-theme-choice` on

--- a/src/lib/contrast.ts
+++ b/src/lib/contrast.ts
@@ -1,13 +1,24 @@
 /**
- * WCAG 2.1 relative luminance and contrast ratio, for opaque sRGB hex colours.
+ * WCAG 2.1 relative luminance and contrast ratio, from sRGB hex colours.
  *
  * This exists so the colour tokens can be checked at build time instead of
- * eyeballed. It is a FLOOR, not a proof: it compares two flat token values,
- * and several surfaces on this site are not flat. The paper grain
- * (`body::before`), the header's `backdrop-filter`, and the hero portrait's
- * `mix-blend-mode: multiply` all sit between the two colours a token pair
- * describes, so a pair can pass here while the rendered pixels fail. Treat a
- * pass as "the tokens are not obviously wrong" and check real surfaces by eye.
+ * eyeballed. It is a FLOOR, not a proof, for two reasons.
+ *
+ * It compares two flat token values, and several surfaces on this site are not
+ * flat. The paper grain (`body::before`), the header's `backdrop-filter`, and
+ * the hero portrait's `mix-blend-mode: multiply` all sit between the two
+ * colours a token pair describes, so a pair can pass here while the rendered
+ * pixels fail.
+ *
+ * And an alpha channel is accepted and ignored rather than rejected: `#rgba`
+ * and `#rrggbbaa` parse, and only the colour channels count. An exact answer
+ * for a translucent colour means compositing it against the backdrop it is
+ * really drawn on, and two flat tokens do not carry a backdrop — so what comes
+ * back is the ratio for that colour at full opacity. To score a translucent
+ * value honestly, composite it yourself and pass the resulting hex in.
+ *
+ * Treat a pass as "the tokens are not obviously wrong" and check real surfaces
+ * by eye.
  *
  * Deliberately no dependency: the whole calculation is a dozen lines and a
  * package would need pinning, auditing, and upgrading for it.
@@ -23,11 +34,11 @@ export const AA_LARGE_TEXT = 3;
 export const AA_NON_TEXT = 3;
 
 /**
- * `#rgb`, `#rrggbb`, or `#rrggbbaa` to 0-255 channels.
+ * `#rgb`, `#rgba`, `#rrggbb`, or `#rrggbbaa` to 0-255 channels.
  *
- * An alpha channel is parsed but ignored: compositing a translucent colour
- * needs a backdrop, and the callers here only ever compare opaque tokens.
- * Anything else throws rather than silently scoring black.
+ * An alpha channel is parsed but ignored, as the header says: compositing a
+ * translucent colour needs a backdrop, and the callers here only ever compare
+ * opaque tokens. Anything else throws rather than silently scoring black.
  */
 export function parseHexColor(hex: string): [number, number, number] {
   const body = hex.trim().replace(/^#/, '');
@@ -41,7 +52,7 @@ export function parseHexColor(hex: string): [number, number, number] {
       : body;
 
   if (!/^[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$/.test(expanded)) {
-    throw new Error(`Not an opaque sRGB hex colour: ${hex}`);
+    throw new Error(`Not an sRGB hex colour: ${hex}`);
   }
 
   return [
@@ -65,7 +76,10 @@ export function relativeLuminance(hex: string): number {
   return 0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b);
 }
 
-/** WCAG 2.1 contrast ratio between two opaque colours, 1 to 21. */
+/**
+ * WCAG 2.1 contrast ratio between two colours, 1 to 21. Any alpha channel is
+ * ignored, so the answer is exact only for opaque values.
+ */
 export function contrastRatio(a: string, b: string): number {
   const la = relativeLuminance(a);
   const lb = relativeLuminance(b);


### PR DESCRIPTION
Three reviewer comments, all the same species: a comment asserting something the code does not do. Two were right. One was right when it was written and has already been fixed on this branch, so nothing is changed there.

## 1. `ThemeToggle` named a cycle order the button never had

The docstring said `Cycles light → dark → system`. `NEXT_CHOICE` in `src/lib/theme.ts` maps `system → light → dark → system`, and `THEME_CHOICES` is `['system', 'light', 'dark']` — so the described order was wrong in both its start state and its sequence.

The rest of the prose around it was already correct and is untouched: `labelFor` derives the next state from `nextThemeChoice` rather than restating it, and the test is already named *"goes system to light to dark and back to system"*. The fix is the one sentence that hardcoded an order, which now points at where the order comes from instead of repeating it — a copy is what drifted in the first place.

## 2. `contrast.ts` header contradicted its own implementation and its own later note

The header said the utility is *"for opaque sRGB hex colours"*. `parseHexColor` accepts 4- and 8-digit hex and ignores the alpha channel, and the `parseHexColor` docstring twenty lines below already said so. Verified:

```
parseHexColor('#abc8')      -> [170, 187, 204]
parseHexColor('#bc770a80')  -> [188, 119, 10]
```

The header now says plainly that an alpha channel is accepted and ignored, and gives it as the **second reason** the file is a floor rather than a proof: an exact answer for a translucent colour means compositing it against the backdrop it is really drawn on, and two flat token values do not carry a backdrop, so what comes back is the ratio at full opacity.

The existing "FLOOR, not a proof" paragraph about the paper grain, the header's `backdrop-filter`, and the portrait's `mix-blend-mode: multiply` is load-bearing and survives intact — it is now the first of the two reasons rather than the only one.

Two smaller mismatches in the same file went with it:

- the signature line listed `#rgb`, `#rrggbb`, `#rrggbbaa` where the code also accepts `#rgba`;
- the throw message read `Not an opaque sRGB hex colour` for input that is not hex at all — an opaque-only message on a parser that accepts alpha. No test pins that string (`contrast.test.ts` asserts a bare `.toThrow()`), and which inputs throw is unchanged.

## 3. `Stats/Personal.tsx` — no change, the comment is already gone

The reported comment was:

```
// ... so this component is never re-rendered and there is nothing to memoize.
```

Copilot was right about it, and it is worth saying why: a parent re-render re-renders a child regardless of the child's own state, so "never re-rendered" is not something React lets a component claim. But it no longer exists. It was introduced in 9c3ae60 and deleted in e11ae17, which made `Personal` a server component again; the file now carries a docstring about that instead.

The invariant it was reaching for is documented where it actually lives — `src/hooks/useLiveReadout.ts`, which states that the ticked value is assigned to `textContent` rather than held in state, and that the one `live` state flip is safe precisely because the content React renders never changes. That is the narrow, true version of the claim, and no change was needed to reach it.

The render-count test that pins this (`advances the readout without re-rendering React`, `src/hooks/__tests__/useLiveAge.test.tsx`) is untouched.

## Verification

Comment-only diff — no behaviour changes and no exported signature changes.

- `npm run format` clean
- `npx biome check .` — 224 files, no fixes
- `npx tsc --noEmit` — clean
- `npx vitest run` — 83 files, **939 passed**, identical to the base branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
