### PR TITLE
fix(test): stop the view-transition guard asserting a rule that is not true

### DIFF
--- a/app/styles/__tests__/stylesheets.test.ts
+++ b/app/styles/__tests__/stylesheets.test.ts
@@ -120,29 +120,21 @@ describe('stylesheet graph', () => {
   });
 });
 
-describe('view transitions', () => {
-  // `@view-transition` is the cross-document API. The App Router intercepts
-  // every `<Link>` into a same-document client navigation, so root-level
-  // view-transition CSS is inert unless Next is asked to drive transitions
-  // itself. Shipping it without the flag is a no-op that reads as a feature.
-  it('are not styled unless next.config.mjs enables them', () => {
-    const styled = [ENTRY, ...stylesheets]
-      .filter((file) =>
-        /@view-transition|::view-transition-(old|new)\b/.test(
-          declarationsOf(file),
-        ),
-      )
-      .map(repoPath);
-
-    if (styled.length === 0) {
-      return;
-    }
-
-    const config = readFileSync(join(REPO_ROOT, 'next.config.mjs'), 'utf8');
-
-    expect(
-      /viewTransition\s*:\s*true/.test(config),
-      `${styled.join(', ')} styles view transitions, but next.config.mjs does not set experimental.viewTransition, so none of it fires`,
-    ).toBe(true);
-  });
-});
+// There was a fourth guard here, asserting that `::view-transition-*` CSS may
+// only exist when `next.config.mjs` sets `experimental.viewTransition`. It is
+// deliberately gone rather than repaired, for two independent reasons.
+//
+// It was false: those pseudo-elements are generated for *any* active view
+// transition, including a same-document one started by
+// `document.startViewTransition()`, which needs no framework flag at all. And
+// it could not have proved what it claimed anyway — it read `next.config.mjs`
+// as text, so a commented-out `viewTransition: true` satisfied it.
+//
+// The honest version — view-transition CSS must be accompanied by something
+// that can start a transition — would have passed the file that motivated the
+// guard: deleted `utilities.css` declared its own `@view-transition
+// { navigation: auto }` trigger. What was actually wrong with it was
+// app-specific (every internal link here goes through `<Link>`, so no
+// same-origin cross-document navigation occurs), and that is a fact about this
+// app's routing, not a rule a stylesheet-graph test can hold. `app/tailwind.css`
+// records it as a comment instead.


### PR DESCRIPTION
Addresses the "changes needed before merge" review on #932. The deletions from that PR — the comment-only `components/forms.css` stub and the inert `app/styles/utilities.css` — are untouched and stay. Only the guard changes.

## The claim the test encoded, and why it is false

`app/styles/__tests__/stylesheets.test.ts` asserted that `::view-transition-*` CSS may exist only if `next.config.mjs` sets `experimental.viewTransition`. Three separate problems, all verified rather than assumed:

1. **Wrong about the platform.** `::view-transition-old/new` are generated for *any* active view transition, including a same-document one started by `document.startViewTransition()`. That path needs no Next flag, no React component, and no `@view-transition` at-rule. The test would have rejected a correct implementation.
2. **Wrong about React.** `<ViewTransition>` does not depend on this flag; Next documents `experimental.viewTransition` as deeper framework integration, not as the trigger.
3. **Could not prove what it claimed.** It read `next.config.mjs` as raw text and tested `/viewTransition\s*:\s*true/`, so a commented-out line satisfied it. Confirmed by running the regex:

   ```
   '// viewTransition: true,'      -> true
   "const s = 'viewTransition: true';" -> true
   ```

## Why it is removed rather than repaired

The honest version of the rule is "view-transition CSS must be accompanied by something that can start a transition" — that is true, framework-neutral, and detectable. It is also worthless here: the deleted `utilities.css` opened with

```css
@view-transition {
  navigation: auto;
}
```

which *is* a trigger. The corrected guard would have passed the exact file that motivated writing it.

What was actually wrong with that file is app-specific: every internal link on this site goes through `<Link>` (checked — the only plain internal `<a href="/…">` in the repo are fixtures in `SlideMenu.test.tsx`), so no same-origin cross-document navigation occurs and the cross-document opt-in never fires. That is a fact about this app's routing, not about the stylesheet graph, and a stylesheet-graph test cannot hold it without going stale the moment the routing changes. `app/tailwind.css` already records it as a comment where a reader adding a transition would look.

So the `describe('view transitions')` block is replaced by a comment explaining why there is no guard, so the same test does not get rewritten by the next person who notices the CSS is gone. That also answers the "149 lines of policy to remove 66 lines of dead CSS" point: the policy is now zero lines of executable rule.

## What stays

The three structural checks, which are unconditionally true and useful independent of any of this — dangling `@import`s, stylesheets unreachable from `app/tailwind.css`, and comment-only placeholder stylesheets. Each one was re-verified by mutation, since a negative assertion that still passes against a broken tree is documentation, not a test:

| Mutation | Result |
| --- | --- |
| `@import './styles/does-not-exist.css'` in `app/tailwind.css` | `resolves every @import to a file that exists` fails |
| unimported `app/styles/mutant.css` | `reaches every stylesheet from app/tailwind.css` fails |
| imported comment-only `components/mutant-stub.css` | `ships no comment-only placeholder stylesheets` fails |

## Verification

`npm run format`, `npx biome check .` (224 files, clean), `npx tsc --noEmit` (exit 0), `npx vitest run` — 938 passing, which is the base's 939 minus the one removed policy test; the file goes 5 tests to 4 and nothing else moves. No source or CSS changed, so there is no export or visual surface to regress.

Note for whoever consolidates `AGENTS.md`: the "No page transitions, on purpose" bullet ends with "Reinstating root-level view-transition CSS requires `experimental.viewTransition` in `next.config.mjs` as well; `app/styles/__tests__/stylesheets.test.ts` fails if the CSS returns without it." Both halves are now false and that sentence should go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
