### PR TITLE
fix(stats): stop leaking a repo path and a hardcoded date into user-facing copy

### DIFF
--- a/src/components/Stats/Personal.tsx
+++ b/src/components/Stats/Personal.tsx
@@ -39,10 +39,17 @@ export default function PersonalStats() {
   return (
     <>
       <Table data={readings} />
+      {/* Names the kind of claim, not the file holding it. The note used to
+          read "come from src/data/profile.json", which is a repository path in
+          front of a visitor who is not reading this file tree. What the
+          provenance column is for survives the rewording: a reader can still
+          tell a declared fact from a counted one, which is the only part of
+          that sentence a reader was ever using. */}
       <p className="stats-source-note" data-source="profile">
-        Profile readings come from src/data/profile.json. The age is computed in
-        your browser from the birth instant recorded there; with no JavaScript
-        it holds the coarser reading taken when this build ran.
+        Profile readings come from the site profile — declared facts, not
+        measurements counted at build time. The age is computed in your browser
+        from the birth instant recorded there; with no JavaScript it holds the
+        coarser reading taken when this build ran.
       </p>
     </>
   );

--- a/src/components/Stats/Site.tsx
+++ b/src/components/Stats/Site.tsx
@@ -29,6 +29,17 @@ interface GitHubStatsResult {
  * when you notice, and treat a build that logs the warning below as a build
  * that shipped approximate numbers.
  *
+ * The note rendered below deliberately carries no date. It used to spell out
+ * "fallback refreshed July 25, 2026" — this snapshot's vintage typed a second
+ * time, in user-facing copy, free to drift from the numbers it dates and
+ * certain to go stale. Nothing here can honestly supply it either: `pushed_at`
+ * is the repository's last push as of capture rather than the capture, and the
+ * build clock is worse, because this constant exists precisely for builds
+ * where the fetch failed and stamping it with the build time would assert a
+ * freshness it does not have. The vintage stays where it already was — the
+ * `pushed_at` below renders as the "Last push to this repository" row — and
+ * the note tells the reader that row is part of the snapshot.
+ *
  * Refreshed: 2026-07-25
  */
 const FALLBACK_DATA: GitHubData = {
@@ -139,7 +150,7 @@ export default async function SiteStats() {
       <p className="stats-source-note" data-source={source}>
         {source === 'github'
           ? 'GitHub readings fetched at build time. Measured readings counted from the working tree of this build.'
-          : 'Approximate GitHub readings — API unavailable; fallback refreshed July 25, 2026. Measured readings counted from the working tree of this build.'}
+          : 'Approximate GitHub readings — API unavailable, so these are last-known values committed to the repository; the push date above is part of that snapshot, not a live reading. Measured readings counted from the working tree of this build.'}
       </p>
     </>
   );

--- a/src/components/__tests__/Stats/Personal.test.tsx
+++ b/src/components/__tests__/Stats/Personal.test.tsx
@@ -104,6 +104,20 @@ describe('Personal', () => {
     expect(note).toHaveAttribute('data-source', 'profile');
   });
 
+  it('describes provenance without naming a repository path', () => {
+    // The note read "come from src/data/profile.json", which is a file tree a
+    // visitor is not looking at. The claim the provenance column exists to
+    // make — declared, not counted — has to survive without the path, because
+    // that is the only part of the sentence a reader was ever using.
+    render(<Personal />);
+
+    const note = screen.getByText(/profile readings come from/i).textContent;
+
+    expect(note).not.toMatch(/src\/data|\.json\b/i);
+    expect(note).toMatch(/declared/i);
+    expect(note).toMatch(/not measurements counted at build time/i);
+  });
+
   it('explains what the age is when JavaScript never runs', () => {
     render(<Personal />);
 

--- a/src/components/__tests__/Stats/Site.test.tsx
+++ b/src/components/__tests__/Stats/Site.test.tsx
@@ -166,6 +166,31 @@ describe('Site', () => {
     );
   });
 
+  it('does not date the fallback note with a hand-typed refresh date', async () => {
+    // "fallback refreshed July 25, 2026" was the snapshot's vintage typed a
+    // second time in user-facing copy — free to drift from the numbers it
+    // dated, and certain to go stale. Nothing here can honestly derive it: the
+    // build clock is exactly the freshness this branch is admitting it lacks.
+    // The vintage stays visible as the `pushed_at` row instead.
+    vi.mocked(global.fetch).mockRejectedValueOnce(new Error('Network error'));
+
+    const Component = await Site();
+    render(Component);
+
+    const note = screen.getByText(/approximate github readings/i);
+
+    // Any typed date carries a year, so a four-digit run is the guard. A month
+    // name is not — "may" is an ordinary word, and a negative assertion that
+    // can fire on prose is a trap for whoever edits this copy next.
+    expect(note.textContent).not.toMatch(/\d{4}/);
+    // The reader is still told these are last-known values and that the date
+    // shown in the table is part of the same snapshot.
+    expect(note.textContent).toMatch(/last-known values/i);
+    expect(note.textContent).toMatch(
+      /push date above is part of that snapshot/i,
+    );
+  });
+
   it('labels live GitHub readings with their provenance', async () => {
     const Component = await Site();
     render(Component);


### PR DESCRIPTION
Implements two Copilot comments on #947. Both are about text a visitor reads on `/stats` that was written for a maintainer reading the file tree.

## 1. `Personal.tsx` — a repository path in user-facing copy

**Was:** `Profile readings come from src/data/profile.json.`

`src/data/profile.json` is an implementation detail; nobody on the page is looking at a file tree. But the path was carrying a real claim — the whole point of the provenance column is that a reader can tell a measured number from a declared one — so the rewording states that claim directly instead of implying it via a filename.

**Now:** `Profile readings come from the site profile — declared facts, not measurements counted at build time.`

Same meaning to a visitor, and it no longer ties the copy to a path that a fork will rename.

## 2. `Site.tsx` — a hardcoded refresh date in the fallback note

**Was:** `Approximate GitHub readings — API unavailable; fallback refreshed July 25, 2026.`

This is the site's own rule turned on itself: a date describing when the committed snapshot was captured, typed into user-facing copy where it can drift from the numbers it dates, and certain to go stale.

I looked for something to derive it from and concluded there is nothing honest:

- **`FALLBACK_DATA.pushed_at`** is the repository's last push *as of capture*, not the capture. The snapshot was taken at or after it, so reporting it as the refresh date asserts something the value does not mean.
- **The build clock** is worse. This branch runs precisely when the live fetch failed; stamping it with the build time would assert a freshness it does not have. (Explicitly ruled out in the task brief, and I agree.)

So the date is dropped rather than invented. That follows the precedent already recorded in AGENTS.md for `meta.lastModified` in `/resume.json`: when a date cannot be honestly derived, omit it rather than publish it meaning something narrower than its name.

Nothing is lost from the page. `pushed_at` already renders as the **Last push to this repository** row, so under fallback the snapshot's vintage is visible in the table itself — the note now points at it instead of restating it.

**Now:** `Approximate GitHub readings — API unavailable, so these are last-known values committed to the repository; the push date above is part of that snapshot, not a live reading.`

The maintainer-facing `Refreshed: 2026-07-25` comment on `FALLBACK_DATA` stays: that is where the fact belongs, next to the data it dates, and it is what tells the next person when to refresh.

### Pre-existing on `main`

Confirmed — `git show origin/main:src/components/Stats/Site.tsx` carries the same `fallback refreshed July 25, 2026` string at line 129. This is not a regression introduced by #932-#946; it is fixed here because the surrounding code is being rewritten on this branch anyway.

## Tests

Two new tests, each **confirmed to go red** against the copy it replaces (checked out the base version of both components and re-ran — 2 failed, 27 passed):

- `Personal.test.tsx` — the note names no repository path (`src/data`, `.json`) and still makes the declared-not-counted claim.
- `Site.test.tsx` — the fallback note contains no four-digit run, and still tells the reader these are last-known values whose date belongs to the snapshot. The year check is the guard rather than a month-name list, since "may" is an ordinary word and a negative assertion that can fire on prose is a trap for whoever edits this copy next.

## Verification

- `npm run format` — clean
- `npx biome check .` — 224 files, no fixes applied
- `npx tsc --noEmit` — clean
- `npx vitest run` — **941 passed** (939 on base + 2 added), 83 files. Default reporter; `--reporter=basic` does not exist in Vitest 4.

No CSS, data, or metadata touched; changes are confined to the two components and their tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
