### PR TITLE
fix(resume): stop a malformed HTML entity crashing the resume.json build

### DIFF
--- a/src/lib/__tests__/resumeJson.test.ts
+++ b/src/lib/__tests__/resumeJson.test.ts
@@ -84,6 +84,56 @@ describe('toPlainText', () => {
     expect(toPlainText('Trust &amp; Safety &#38; more')).toBe(
       'Trust & Safety & more',
     );
+    // The same character named three ways, so the range guard below cannot be
+    // satisfied by refusing everything numeric.
+    expect(toPlainText('&amp; &#38; &#x26;')).toBe('& & &');
+  });
+
+  it('decodes the last code point Unicode defines', () => {
+    // 0x10FFFF is the boundary: valid, and one above it is not.
+    expect(toPlainText('edge &#x10FFFF; case')).toBe(
+      `edge ${String.fromCodePoint(0x10ffff)} case`,
+    );
+    expect(toPlainText('edge &#1114111; case')).toBe(
+      `edge ${String.fromCodePoint(0x10ffff)} case`,
+    );
+  });
+
+  it('leaves an out-of-range numeric entity intact instead of throwing', () => {
+    // `String.fromCodePoint` throws a `RangeError` above 0x10FFFF, which would
+    // fail the `/resume.json` build over one mistyped entity in a summary.
+    // Same fallback as an unknown named entity: the source text stays put.
+    expect(() => toPlainText('a &#99999999; b')).not.toThrow();
+    expect(toPlainText('a &#99999999; b')).toBe('a &#99999999; b');
+    expect(toPlainText('a &#x6000000; b')).toBe('a &#x6000000; b');
+    // 0x110000, the first invalid code point, in both bases.
+    expect(toPlainText('a &#x110000; b')).toBe('a &#x110000; b');
+    expect(toPlainText('a &#1114112; b')).toBe('a &#1114112; b');
+  });
+
+  it('leaves a lone surrogate as text rather than emitting an unpaired one', () => {
+    // This one does not throw — `String.fromCodePoint(0xd800)` returns half a
+    // surrogate pair, which would reach the artifact as a `\ud800` escape that
+    // decodes to nothing readable. Refused for that reason, not for safety.
+    const decoded = toPlainText('a &#xD800; b');
+
+    expect(decoded).toBe('a &#xD800; b');
+    expect(decoded.isWellFormed()).toBe(true);
+    expect(toPlainText('a &#xDFFF; b')).toBe('a &#xDFFF; b');
+    expect(toPlainText('a &#55296; b')).toBe('a &#55296; b');
+    // The characters either side of the block still decode, so the refusal is
+    // the surrogate range and not everything near it.
+    expect(toPlainText('&#xD7FF;&#xE000;')).toBe(
+      `${String.fromCodePoint(0xd7ff)}${String.fromCodePoint(0xe000)}`,
+    );
+  });
+
+  it('leaves an entity it cannot name a character for intact', () => {
+    // `&#abc;` parses to NaN, and every comparison against NaN is false, so it
+    // reaches the same fallback as the out-of-range cases without a check of
+    // its own. An unrecognised named entity has always taken that fallback.
+    expect(toPlainText('a &#abc; b')).toBe('a &#abc; b');
+    expect(toPlainText('a &nope; b')).toBe('a &nope; b');
   });
 
   it('leaves underscores alone so identifiers survive', () => {

--- a/src/lib/resumeJson.ts
+++ b/src/lib/resumeJson.ts
@@ -109,15 +109,53 @@ const NAMED_ENTITIES: Record<string, string> = {
   quot: '"',
 };
 
+/** The largest code point Unicode defines. */
+const MAX_CODE_POINT = 0x10ffff;
+
+/** The UTF-16 surrogate block — code points, but not characters. */
+const FIRST_SURROGATE = 0xd800;
+const LAST_SURROGATE = 0xdfff;
+
+/**
+ * Whether `String.fromCodePoint` can be handed this and produce a character.
+ *
+ * Two ways a numeric entity fails to name one, and they fail differently.
+ * Above `MAX_CODE_POINT`, `String.fromCodePoint` throws a `RangeError` — a
+ * single mistyped `&#99999999;` in a `src/data/resume/work.ts` summary would
+ * take down `npm run build` rather than degrade, because nothing between here
+ * and the `/resume.json` route handler catches it. Inside the surrogate block
+ * it throws nothing and returns an unpaired code unit instead, which travels
+ * into the artifact as a `\ud800` escape and leaves the published document
+ * holding a string no consumer can decode to text.
+ *
+ * Both are refused by leaving the source text exactly where it is, which is
+ * already what this function does for an unknown named entity: a visible
+ * `&#99999999;` in the published résumé is a bug someone can read, where a
+ * failed build is a bug nobody can publish around and a lone surrogate is a bug
+ * nobody can see.
+ *
+ * The `NaN` a non-numeric run like `&#abc;` parses to needs no clause of its
+ * own: every comparison against `NaN` is false, so it fails both of these the
+ * way it failed the `Number.isNaN` check this replaced. That check was dead
+ * code — deleting it left the suite green, which is how it was found.
+ */
+function isDecodableCodePoint(codePoint: number): boolean {
+  return (
+    codePoint <= MAX_CODE_POINT &&
+    (codePoint < FIRST_SURROGATE || codePoint > LAST_SURROGATE)
+  );
+}
+
 function decodeEntity(entity: string): string {
+  const literal = `&${entity};`;
   const numeric = entity.match(/^#(x)?([0-9a-f]+)$/i);
   if (numeric) {
     const codePoint = Number.parseInt(numeric[2], numeric[1] ? 16 : 10);
-    return Number.isNaN(codePoint)
-      ? `&${entity};`
-      : String.fromCodePoint(codePoint);
+    return isDecodableCodePoint(codePoint)
+      ? String.fromCodePoint(codePoint)
+      : literal;
   }
-  return NAMED_ENTITIES[entity.toLowerCase()] ?? `&${entity};`;
+  return NAMED_ENTITIES[entity.toLowerCase()] ?? literal;
 }
 
 /**


### PR DESCRIPTION
Implements Copilot's review comment on #939 (`src/lib/resumeJson.ts`, ~line 121).

## The claim, reproduced

> `decodeEntity` can throw a `RangeError` when decoding numeric entities outside the valid Unicode scalar range.

Confirmed against the shipped code before changing anything:

| entity | old `decodeEntity` |
| --- | --- |
| `&#99999999;` | **throws** `RangeError: Invalid code point 99999999` |
| `&#x6000000;` | **throws** `RangeError: Invalid code point 100663296` |
| `&#1114112;` (`0x110000`) | **throws** `RangeError: Invalid code point 1114112` |
| `&#1114111;` (`0x10FFFF`) | decodes — this is the boundary |
| `&#xD800;` | does *not* throw; returns a lone surrogate |

`Number.isNaN` was the only guard, and an out-of-range value is a perfectly
good number. `toPlainText` is called from `buildWork()` on every `summary` and
every `highlights` entry, so one mistyped entity in `src/data/resume/work.ts`
fails `npm run build` — nothing between there and the `/resume.json` route
handler catches it.

## The fix

Validate the code point before handing it to `String.fromCodePoint`, and fall
back to leaving the entity text exactly where it is — the same thing the
function already does for an unknown named entity.

```ts
function isDecodableCodePoint(codePoint: number): boolean {
  return (
    codePoint <= MAX_CODE_POINT &&
    (codePoint < FIRST_SURROGATE || codePoint > LAST_SURROGATE)
  );
}
```

## Lone surrogates: refused, deliberately

`String.fromCodePoint(0xD800)` does not throw. It returns half a surrogate
pair, which `JSON.stringify` faithfully writes into `/resume.json` as a
`\ud800` escape — a string no consumer can decode to text, sitting in an
artifact whose entire job is being machine-readable.

Refusing it and leaving `&#xD800;` as literal text is the safer of the two:

- It matches what the function already does for every other input it cannot
  turn into a character, so there is one fallback rather than three.
- A visible `&#xD800;` in the published résumé is a bug a person can read.
  A lone surrogate is a bug nobody can see — it renders as nothing, validates
  as a string, and only surfaces in whatever downstream tool finally chokes on
  it.
- The HTML standard also declines to emit surrogates from numeric references
  (it substitutes U+FFFD); substituting here would be inventing a character the
  résumé never contained, where leaving the text alone invents nothing.

The characters immediately either side of the block (`&#xD7FF;`, `&#xE000;`)
still decode, so the refusal is the surrogate range and not everything near it.

## The removed `Number.isNaN` check

It is gone rather than kept alongside the new clauses. Every comparison against
`NaN` is false, so `NaN` already fails `<= MAX_CODE_POINT`. It was dead code —
deleting it left the entire suite green, which is how it was found during the
mutation sweep below. `&#abc;` (the input that produces the `NaN`) is still
pinned by a test, and the behaviour is unchanged.

No lower bound is checked on purpose: the entity regex matches `[0-9a-f]+`, so
nothing can reach a negative code point, and a guard no input can reach is not
a guard — it is an untestable line.

## Tests

Four new cases in `src/lib/__tests__/resumeJson.test.ts`, covering everything
the review asked for:

- huge decimal (`&#99999999;`) and huge hex (`&#x6000000;`), asserted both
  not-to-throw and to come through as literal text
- the boundaries in both bases: `0x10FFFF` / `1114111` decode, `0x110000` /
  `1114112` do not
- lone surrogates `&#xD800;`, `&#xDFFF;`, `&#55296;` left intact, with
  `isWellFormed()` asserted on the result; `&#xD7FF;` and `&#xE000;` still
  decode
- `&amp;`, `&#38;`, and `&#x26;` all still produce `&`, so the guard cannot be
  satisfied by refusing everything numeric

## Mutation-verified

Every mutation of the new guard was confirmed to turn the file red:

| mutation | result |
| --- | --- |
| drop the `<= MAX_CODE_POINT` clause | RED |
| drop the surrogate-block clause | RED |
| `<= MAX_CODE_POINT` → `<` | RED |
| `< FIRST_SURROGATE` → `<=` | RED |
| `> LAST_SURROGATE` → `>=` | RED |
| `MAX_CODE_POINT` → `0xffff` | RED |
| `MAX_CODE_POINT` → `0x110000` | RED |
| whole predicate → `return true` | RED |
| numeric fallback → `U+FFFD` | RED |
| named-entity fallback → `''` | RED |

The first sweep is also what caught the redundant `Number.isNaN` line: it was
the one mutant that survived.

## Verification

- `npm run format` — no churn beyond the two files
- `npx biome check .` — clean, 224 files
- `npx tsc --noEmit` — clean
- `npx vitest run` — 83 files, **943 passed** (939 on the base + 4 new)

The built document is unchanged: no entity in the current résumé data is
affected, and the byte-stability tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
