### PR TITLE
fix(resume): freeze the clock in the chronology test and correct the `now` docs

### DIFF
--- a/app/__tests__/resume-chronology.test.tsx
+++ b/app/__tests__/resume-chronology.test.tsx
@@ -1,15 +1,50 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import work from '@/data/resume/work';
 import { sortPositions, totalExperienceYears } from '@/lib/career';
 import ResumePage from '../resume/page';
 
 /**
+ * The instant the whole suite renders against.
+ *
+ * `ResumePage` reads the clock once during render. A test that reads it again
+ * to build its expectation is comparing two instants, and the two disagree by
+ * a whole year whenever they straddle the anniversary of the earliest role —
+ * `totalExperienceYears` steps there. The window is narrow and the failure
+ * would be unreproducible, which is the worst shape a test failure comes in,
+ * so the clock is frozen and both sides share one reading.
+ *
+ * Local time, deliberately: dayjs parses the `YYYY-MM-DD` strings in
+ * `src/data/resume/work.ts` as local midnight, so pinning a UTC instant would
+ * sit a timezone offset away from the dates it is compared against.
+ */
+const FROZEN_NOW = new Date(2026, 6, 28, 12, 0, 0);
+
+/** The `N+ years` figure the page states, read back out of the summary. */
+function statedSpan(container: HTMLElement): number {
+  const summary = container.querySelector('.resume-summary')?.textContent ?? '';
+  const stated = summary.match(/(\d+)\+ years/);
+
+  expect(stated).not.toBeNull();
+
+  return Number(stated?.[1]);
+}
+
+/**
  * Two properties of the resume page that used to be maintained by hand:
  * the order of the experience spine, and the length of the career it claims.
  */
 describe('resume chronology', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('renders the spine newest first', () => {
     const { container } = render(<ResumePage />);
 
@@ -21,16 +56,31 @@ describe('resume chronology', () => {
   });
 
   it('states the career span once, derived from the earliest role', () => {
-    render(<ResumePage />);
+    const { container } = render(<ResumePage />);
 
-    const years = totalExperienceYears(work, Date.now());
-    const summary = screen.getByText(/Engineering leader/);
+    const years = totalExperienceYears(work, FROZEN_NOW.getTime());
+    const summary = container.querySelector('.resume-summary');
 
-    expect(summary.textContent).toContain(`${years}+ years`);
+    expect(summary?.textContent).toContain(`${years}+ years`);
 
     // One number, stated once. Showing the elapsed span next to a
     // months-occupied figure reads as hedging rather than as precision.
-    expect(summary.textContent?.match(/\d+\+? years?/g)).toHaveLength(1);
+    expect(summary?.textContent?.match(/\d+\+? years?/g)).toHaveLength(1);
+  });
+
+  /**
+   * The span is counted from the clock, not written down — so moving the clock
+   * has to move it. This is also what proves the freeze above reaches the page
+   * rather than quietly pinning nothing: if `ResumePage` ever stopped reading
+   * `Date.now()`, both renders would report the same figure.
+   */
+  it('counts the span from the clock rather than a fixed value', () => {
+    const { container } = render(<ResumePage />);
+
+    vi.setSystemTime(new Date(2031, 6, 28, 12, 0, 0));
+    const { container: fiveYearsOn } = render(<ResumePage />);
+
+    expect(statedSpan(fiveYearsOn)).toBe(statedSpan(container) + 5);
   });
 
   it('gives every role a tenure derived from its own dates', () => {

--- a/src/components/Resume/Experience.tsx
+++ b/src/components/Resume/Experience.tsx
@@ -6,9 +6,13 @@ import Job, { type JobTier } from './Experience/Job';
 interface ExperienceProps {
   data: Position[];
   /**
-   * Instant an ongoing role's tenure is measured to. Read once by the caller
-   * and threaded down so every duration on the spine agrees with the headline
-   * span on the page.
+   * Instant every ongoing role's tenure is measured to.
+   *
+   * Optional, and omitting it does read the clock — but exactly once, here,
+   * and the reading is then threaded to every role, so the durations on the
+   * spine always agree with each other. `app/resume/page.tsx` supplies its own
+   * read so they also agree with the headline span above them, and a test can
+   * pin the instant instead of racing the clock.
    */
   now?: DateInput;
 }
@@ -59,6 +63,8 @@ export function tierFor(job: Position, positions: Position[]): JobTier {
 
 export default function Experience({
   data,
+  // The single fallback read. `Job` requires the instant precisely so this
+  // cannot quietly become one read per role.
   now = Date.now(),
 }: ExperienceProps) {
   // `tierFor` was written not to depend on array position; sorting here is the

--- a/src/components/Resume/Experience/Job.tsx
+++ b/src/components/Resume/Experience/Job.tsx
@@ -12,18 +12,18 @@ interface JobProps {
   data: Position;
   tier?: JobTier;
   /**
-   * Instant an ongoing role is measured to. Taken as a prop rather than read
-   * from the clock here so the figure is deterministic and every role on the
-   * spine is measured against the same moment.
+   * Instant an ongoing role is measured to. Required rather than defaulted to
+   * `Date.now()`, because a default is one clock read *per role*: a spine of
+   * ongoing roles would each measure themselves against their own instant, and
+   * the disagreement is invisible until two reads straddle a month boundary.
+   * Requiring it is the same contract `positionDuration` in `src/lib/career.ts`
+   * sets, for the same reason — the figure stays deterministic and a test can
+   * pin it. `Experience` reads the clock once and threads it here.
    */
-  now?: DateInput;
+  now: DateInput;
 }
 
-export default function Job({
-  data,
-  tier = 'primary',
-  now = Date.now(),
-}: JobProps) {
+export default function Job({ data, tier = 'primary', now }: JobProps) {
   const { name, position, url, startDate, endDate, summary, highlights } = data;
   const isCurrent = !endDate;
   // Derived from the dates rather than written out per role, so it cannot

--- a/src/components/__tests__/Resume/Experience.test.tsx
+++ b/src/components/__tests__/Resume/Experience.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import Experience from '../../Resume/Experience';
 
@@ -24,6 +24,12 @@ const mockJobs = [
 ];
 
 describe('Experience', () => {
+  // Only the fallback-read test fakes the clock, but the suite is shuffled, so
+  // the restore has to be unconditional.
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('renders the experience section with title', () => {
     render(<Experience data={mockJobs} />);
 
@@ -122,6 +128,31 @@ describe('Experience', () => {
     ).map((node) => node.textContent);
 
     // 2020-01-01 and 2018-01-01 respectively, both measured to `now`.
+    expect(durations).toEqual(['6 yr 6 mo', '8 yr 6 mo']);
+  });
+
+  /**
+   * `now` is optional here and omitting it does read the clock — but once, at
+   * the top of the section, and the reading is threaded to every role. `Job`
+   * requires the instant so that stays true; this pins the fallback path.
+   */
+  it('falls back to one clock read shared by the whole spine', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 6, 28, 12, 0, 0));
+
+    render(
+      <Experience
+        data={[
+          { ...mockJobs[0], name: 'Still Going', endDate: undefined },
+          { ...mockJobs[1], name: 'Also Going', endDate: undefined },
+        ]}
+      />,
+    );
+
+    const durations = Array.from(
+      document.querySelectorAll('.daterange-duration'),
+    ).map((node) => node.textContent);
+
     expect(durations).toEqual(['6 yr 6 mo', '8 yr 6 mo']);
   });
 });

--- a/src/components/__tests__/Resume/Job.test.tsx
+++ b/src/components/__tests__/Resume/Job.test.tsx
@@ -3,6 +3,13 @@ import { describe, expect, it } from 'vitest';
 
 import Job from '../../Resume/Experience/Job';
 
+/**
+ * `Job` requires the instant an ongoing role is measured to, so no test here
+ * can accidentally measure against the clock the suite happens to run on.
+ * Local time, to match the local midnight dayjs reads the ISO dates as.
+ */
+const NOW = new Date(2026, 6, 28, 12, 0, 0).getTime();
+
 describe('Job', () => {
   const mockJob = {
     name: 'Acme Corp',
@@ -15,14 +22,14 @@ describe('Job', () => {
   };
 
   it('renders company name with link', () => {
-    render(<Job data={mockJob} />);
+    render(<Job data={mockJob} now={NOW} />);
 
     const link = screen.getByRole('link', { name: /acme corp/i });
     expect(link).toHaveAttribute('href', 'https://acme.com');
   });
 
   it('renders position title', () => {
-    render(<Job data={mockJob} />);
+    render(<Job data={mockJob} now={NOW} />);
 
     expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent(
       'Senior Engineer',
@@ -30,7 +37,7 @@ describe('Job', () => {
   });
 
   it('formats date range correctly', () => {
-    render(<Job data={mockJob} />);
+    render(<Job data={mockJob} now={NOW} />);
 
     expect(screen.getByText(/january 2020/i)).toBeInTheDocument();
     expect(screen.getByText(/june 2023/i)).toBeInTheDocument();
@@ -42,20 +49,20 @@ describe('Job', () => {
       endDate: undefined,
     };
 
-    render(<Job data={currentJob} />);
+    render(<Job data={currentJob} now={NOW} />);
 
     expect(screen.getByText(/present/i)).toBeInTheDocument();
   });
 
   it('renders summary with markdown', () => {
-    render(<Job data={mockJob} />);
+    render(<Job data={mockJob} now={NOW} />);
 
     // Summary text should be present
     expect(screen.getByText(/led development of/i)).toBeInTheDocument();
   });
 
   it('renders highlights as list items', () => {
-    render(<Job data={mockJob} />);
+    render(<Job data={mockJob} now={NOW} />);
 
     expect(screen.getByText('Shipped feature X')).toBeInTheDocument();
     expect(screen.getByText('Improved performance by 50%')).toBeInTheDocument();
@@ -70,7 +77,7 @@ describe('Job', () => {
       summary: undefined,
     };
 
-    render(<Job data={jobWithoutSummary} />);
+    render(<Job data={jobWithoutSummary} now={NOW} />);
 
     // Should not crash, highlights should still render
     expect(screen.getByText('Shipped feature X')).toBeInTheDocument();
@@ -82,7 +89,7 @@ describe('Job', () => {
       highlights: undefined,
     };
 
-    render(<Job data={jobWithoutHighlights} />);
+    render(<Job data={jobWithoutHighlights} now={NOW} />);
 
     // Should not crash, summary should still render
     expect(screen.getByText(/led development/i)).toBeInTheDocument();
@@ -92,14 +99,14 @@ describe('Job', () => {
   });
 
   it('renders as article element', () => {
-    render(<Job data={mockJob} />);
+    render(<Job data={mockJob} now={NOW} />);
 
     const article = document.querySelector('article.jobs-container');
     expect(article).toBeInTheDocument();
   });
 
   it('derives the tenure from the two dates', () => {
-    render(<Job data={mockJob} />);
+    render(<Job data={mockJob} now={NOW} />);
 
     // 2020-01-15 to 2023-06-30.
     expect(document.querySelector('.daterange-duration')?.textContent).toBe(
@@ -107,21 +114,34 @@ describe('Job', () => {
     );
   });
 
+  /**
+   * Rendered at two instants rather than one: a single reading is also what a
+   * component reading the clock for itself would produce, so only the second
+   * render distinguishes the required prop from a default.
+   */
   it('measures an ongoing role to the instant it is given', () => {
-    render(
+    const { container } = render(
+      <Job data={{ ...mockJob, endDate: undefined }} now={NOW} />,
+    );
+    const { container: aYearOn } = render(
       <Job
         data={{ ...mockJob, endDate: undefined }}
-        now={new Date('2026-07-28T12:00:00Z').getTime()}
+        now={new Date(2027, 6, 28, 12, 0, 0).getTime()}
       />,
     );
 
-    expect(document.querySelector('.daterange-duration')?.textContent).toBe(
+    // Both from 2020-01-15, to the given instant rather than to whenever the
+    // suite runs.
+    expect(container.querySelector('.daterange-duration')?.textContent).toBe(
       '6 yr 6 mo',
+    );
+    expect(aYearOn.querySelector('.daterange-duration')?.textContent).toBe(
+      '7 yr 6 mo',
     );
   });
 
   it('keeps the tenure inside the date range so it shares the gutter', () => {
-    render(<Job data={mockJob} />);
+    render(<Job data={mockJob} now={NOW} />);
 
     const duration = document.querySelector('.daterange-duration');
     expect(duration?.parentElement).toHaveClass('daterange');
@@ -133,7 +153,7 @@ describe('Job', () => {
    * meaning anything, so the tenure stays quiet on every role.
    */
   it('does not claim the live signal for the tenure', () => {
-    render(<Job data={{ ...mockJob, endDate: undefined }} />);
+    render(<Job data={{ ...mockJob, endDate: undefined }} now={NOW} />);
 
     expect(document.querySelector('.daterange-duration')).not.toHaveClass(
       'daterange-present',


### PR DESCRIPTION
Three Copilot comments on #934. All three were valid; one of them was valid in a
stronger form than it was stated.

## 1. The chronology test read the clock twice

`ResumePage` reads `Date.now()` once during render. The test then read the clock
*again* to build its expectation:

```tsx
render(<ResumePage />);
const years = totalExperienceYears(work, Date.now());
```

Two instants. They disagree by a whole year whenever they straddle the
anniversary of the earliest role in `src/data/resume/work.ts` — that is exactly
where `totalExperienceYears` steps. The window is narrow, but the failure it
produces is a once-a-year unreproducible red build, which is the worst shape a
test failure comes in.

The suite now freezes the clock (`vi.useFakeTimers` + `vi.setSystemTime`) in
`beforeEach` and restores real timers in `afterEach` — unconditionally, because
`vitest.config.ts` sets `sequence.shuffle`. Render and assertion share one
reading.

The instant is built with the local-time `Date` constructor rather than a UTC
literal, because dayjs parses the `YYYY-MM-DD` strings in `work.ts` as local
midnight; a UTC instant would sit a timezone offset away from the dates it is
compared against. Verified by running the affected suites under `TZ=Pacific/Kiritimati`
(UTC+14) and `TZ=Pacific/Midway` (UTC-11).

A frozen clock is worthless if it does not actually reach the page, so the freeze
is itself pinned: a new test renders five years apart and requires the stated span
to move by five. Confirmed to have teeth by temporarily replacing the page's
`Date.now()` with a literal — both assertions go red.

## 2 & 3. `now` documented as caller-supplied while defaulting to the clock

`Job`'s JSDoc said the instant was "taken as a prop rather than read from the
clock here so the figure is deterministic", directly above `now = Date.now()`.

The comment described the better design, so the code moved rather than the
comment. `now` is now **required** on `Job`, matching `positionDuration` in
`src/lib/career.ts`, which takes it as a required argument for exactly this
reason. A default is one clock read *per role*, so nothing structurally stopped a
spine of ongoing roles from measuring themselves against different instants — a
disagreement invisible until two reads straddle a month boundary.

`Experience` keeps its optional `now`. Its default genuinely is a *single* read,
threaded to every role, so the property the comment claims holds on the fallback
path too — and that is now guaranteed by `Job`'s signature rather than asserted in
prose. Its comment was reworded to say what the code does ("omitting it does read
the clock — but exactly once, here"), and a new test pins the fallback path.
Requiring it there as well would have meant editing `app/__tests__/resume-anchors.test.tsx`,
which is outside this change's scope.

## Verification

- `npm run format`, `npx biome check .` clean, `npx tsc --noEmit` clean
- `npx vitest run`: **941 passed** (939 on base + 2; the third new case was
  folded into the existing `Job` instant test rather than duplicating it)
- Affected suites re-run under three timezones
- Mutation-checked: the new clock test fails when the page stops reading the clock

🤖 Generated with [Claude Code](https://claude.com/claude-code)
