### PR TITLE
fix(scripts): keep --json stdout parseable and reject non-numeric budgets

### DIFF
--- a/scripts/__tests__/measure-export.test.ts
+++ b/scripts/__tests__/measure-export.test.ts
@@ -28,6 +28,16 @@ const ICON =
 
 const ASSET_BYTES = CSS.length + JS.length + FONT.length;
 
+/** Everything a known budget key can hold that is not a byte count. */
+const INVALID_BUDGET_VALUES: [shape: string, value: unknown][] = [
+  ['a string', '1024'],
+  ['null', null],
+  ['a boolean', true],
+  ['an object', { bytes: 1024 }],
+  ['a negative number', -1],
+  ['a fraction', 1024.5],
+];
+
 /** Generous enough that only the budget under test can trip. */
 const GENEROUS_BUDGET = {
   _policy: ['fixture'],
@@ -133,6 +143,8 @@ function runMeasurer(root: string, args: string[] = []) {
   });
   return {
     status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
     output: `${result.stdout}${result.stderr}`,
   };
 }
@@ -298,6 +310,78 @@ describe('measure-export', () => {
     expect(output).toContain('unknown budget(s): cssByte');
   });
 
+  // A known key holding something that is not a byte count used to be read as
+  // "no budget for this metric", so the gate quietly stopped gating.
+  it.each(INVALID_BUDGET_VALUES)(
+    'rejects a budget committed as %s',
+    (_shape, value) => {
+      const { root } = createFixture({
+        budget: { ...GENEROUS_BUDGET, cssBytes: value },
+      });
+
+      const { status, output } = runMeasurer(root);
+      expect(status).toBe(1);
+      expect(output).toContain('invalid budget(s): cssBytes');
+      expect(output).not.toContain('budget(s) within limits');
+    },
+  );
+
+  it('names every invalid budget, not just the first', () => {
+    const { root } = createFixture({
+      budget: { ...GENEROUS_BUDGET, cssBytes: null, fontBytes: '1024' },
+    });
+
+    const { status, output } = runMeasurer(root);
+    expect(status).toBe(1);
+    expect(output).toContain(
+      'invalid budget(s): cssBytes is null, fontBytes is "1024"',
+    );
+  });
+
+  it('rejects a budget that overflowed to Infinity', () => {
+    const { root } = createFixture();
+    // JSON has no Infinity literal, but `1e999` parses to one — and it is the
+    // worst of these, because it counts as a gated metric that can never be
+    // exceeded, so the run reports a budget it is not enforcing.
+    write(root, 'scripts/budget.json', '{"_policy": [], "cssBytes": 1e999}');
+
+    const { status, output } = runMeasurer(root);
+    expect(status).toBe(1);
+    expect(output).toContain('invalid budget(s): cssBytes is Infinity');
+  });
+
+  it('treats a zero budget as a real limit rather than an invalid one', () => {
+    const { root } = createFixture({
+      budget: { ...GENEROUS_BUDGET, repeatedInlineSvgBytes: 0 },
+    });
+
+    // `0` is the one edge of the rule that has to stay usable: it is how a
+    // metric is held at nothing.
+    const { status, output } = runMeasurer(root);
+    expect(status).toBe(1);
+    expect(output).not.toContain('invalid budget(s)');
+    expect(output).toContain(
+      'inline SVG repeated across documents (repeatedInlineSvgBytes)',
+    );
+  });
+
+  it.each(['42', '"1024"', '[1, 2]', 'null'])(
+    'rejects a budget file whose root is %s',
+    (contents) => {
+      const { root } = createFixture();
+      write(root, 'scripts/budget.json', contents);
+
+      // `42` is valid JSON declaring no budgets at all, so it used to gate
+      // nothing and exit 0; `null` took `Object.keys` down with a stack trace.
+      const { status, output } = runMeasurer(root);
+      expect(status).toBe(1);
+      expect(output).toContain(
+        'scripts/budget.json must be a JSON object mapping budget names to bytes',
+      );
+      expect(output).not.toContain('budget(s) within limits');
+    },
+  );
+
   it('requires a committed budget file', () => {
     const { root } = createFixture({ budget: null });
 
@@ -327,6 +411,55 @@ describe('measure-export', () => {
     expect(budget.maxRouteFirstLoadBytes).toBe(
       Math.ceil((heaviest * 1.15) / 1024) * 1024,
     );
+  });
+
+  // `--json -` is documented as machine-readable output. The table used to be
+  // printed to stdout ahead of it, so nothing could parse the stream.
+  it.each<[flag: string, args: string[]]>([
+    ['--json -', ['--json', '-']],
+    ['--json=-', ['--json=-']],
+  ])('writes only JSON to stdout for `%s`', (_flag, args) => {
+    const { root, documents } = createFixture();
+    const { status, stdout, stderr } = runMeasurer(root, args);
+
+    expect(status).toBe(0);
+    const report = JSON.parse(stdout) as Report;
+    expect(report.total.files).toBe(11);
+    expect(routeIn(report, '/about/')?.documentBytes).toBe(
+      documents['/about/'],
+    );
+
+    // Suppressed nowhere: the human narrative moves to stderr, so
+    // `--json - >report.json` still shows the table in the terminal.
+    expect(stdout).not.toContain('by subsystem');
+    expect(stderr).toContain('by subsystem');
+    expect(stderr).toContain('7 budget(s) within limits');
+  });
+
+  it('keeps stdout parseable when a budget fails', () => {
+    const { root } = createFixture({
+      budget: { ...GENEROUS_BUDGET, cssBytes: 1024 },
+    });
+
+    const { status, stdout, stderr } = runMeasurer(root, ['--json', '-']);
+    expect(status).toBe(1);
+    expect(checkIn(JSON.parse(stdout) as Report, 'cssBytes')).toMatchObject({
+      limit: 1024,
+      ok: false,
+    });
+    expect(stderr).toContain('1 budget(s) exceeded');
+  });
+
+  it('still prints the table to stdout when the report goes to a file', () => {
+    const { root } = createFixture();
+
+    // The redirect is for `-` only; a person running `--json report.json`
+    // wants both.
+    const { status, stdout } = runMeasurer(root, ['--json', 'report.json']);
+    expect(status).toBe(0);
+    expect(stdout).toContain('by subsystem');
+    expect(stdout).toContain('wrote report.json');
+    expect(stdout).toContain('7 budget(s) within limits');
   });
 
   it('fails when there is nothing to measure', () => {

--- a/scripts/measure-export.mjs
+++ b/scripts/measure-export.mjs
@@ -16,6 +16,7 @@
  * Run after `npm run build`:
  *   npm run measure-export                       table plus budget gate
  *   npm run measure-export -- --json report.json also write the raw numbers
+ *   npm run measure-export -- --json -           raw numbers on stdout instead
  *   npm run measure-export -- --update-budget    ratchet scripts/budget.json
  */
 import {
@@ -346,6 +347,16 @@ const BUDGET_METRICS = [
 const withHeadroom = ({ headroom }, value) =>
   Math.ceil((value * (1 + headroom)) / 1024) * 1024;
 
+/** Keys documenting the file rather than gating a metric. */
+const isCommentKey = (key) => key.startsWith('_');
+
+/**
+ * `JSON.stringify` renders Infinity as `null` and would name the wrong mistake,
+ * so numbers are described by `String` and everything else as its JSON.
+ */
+const describeBudget = (value) =>
+  typeof value === 'number' ? String(value) : JSON.stringify(value);
+
 function readBudget() {
   if (!existsSync(BUDGET_PATH)) {
     if (options.updateBudget) return {};
@@ -362,11 +373,21 @@ function readBudget() {
     die(`scripts/budget.json is not valid JSON: ${error.message}`);
   }
 
+  // A bare number or string is valid JSON that declares no budgets at all, so
+  // the run would gate nothing and still exit green; `null` did not even get
+  // that far, it took `Object.keys` down with a stack trace.
+  if (budget === null || typeof budget !== 'object' || Array.isArray(budget)) {
+    die(
+      'scripts/budget.json must be a JSON object mapping budget names to ' +
+        `bytes, not ${describeBudget(budget)}.`,
+    );
+  }
+
   // A typo in a budget key would otherwise read as "this metric is not gated",
   // which is the one failure mode a budget file must not have.
   const known = new Set(BUDGET_METRICS.map(({ id }) => id));
   const unknown = Object.keys(budget).filter(
-    (key) => !key.startsWith('_') && !known.has(key),
+    (key) => !isCommentKey(key) && !known.has(key),
   );
   if (unknown.length > 0) {
     die(
@@ -375,19 +396,42 @@ function readBudget() {
     );
   }
 
+  // The same failure mode one level down. A budget accidentally committed as a
+  // string, or as `null`, used to be read as "no budget" and stopped gating
+  // without saying so. Infinity is worse: JSON has no literal for it but
+  // `1e999` parses to one, and it counts as a gated metric that can never be
+  // exceeded. A negative or fractional byte count gates something, but nothing
+  // a person meant, so the whole rule is one predicate.
+  const invalid = Object.entries(budget).filter(
+    ([key, value]) =>
+      !isCommentKey(key) && !(Number.isInteger(value) && value >= 0),
+  );
+  if (invalid.length > 0) {
+    const named = invalid
+      .map(([key, value]) => `${key} is ${describeBudget(value)}`)
+      .join(', ');
+    die(
+      `scripts/budget.json has invalid budget(s): ${named}. ` +
+        'Every budget must be a whole number of bytes, 0 or greater.',
+    );
+  }
+
   return budget;
 }
 
 const budget = readBudget();
 
+// `readBudget` has already rejected every value that is not a byte count, so an
+// `undefined` limit here means the key is absent, which is the one documented
+// way to leave a metric ungated. Coercing here instead is what let a mistyped
+// value pass for that.
 const checks = BUDGET_METRICS.map((metric) => {
   const actual = metric.read(report);
-  const limit = budget[metric.id];
   return {
     id: metric.id,
     label: metric.label,
     actual,
-    limit: typeof limit === 'number' ? limit : undefined,
+    limit: budget[metric.id],
     suggested: withHeadroom(metric, actual),
   };
 }).map((check) => ({
@@ -408,6 +452,18 @@ report.budget = {
 // ---------------------------------------------------------------------------
 // Output
 // ---------------------------------------------------------------------------
+
+/**
+ * `--json -` hands stdout to the machine, so the human narrative moves to
+ * stderr rather than being dropped: `--json - >report.json` still prints the
+ * table in the terminal, and the budget failures below are already there.
+ * Every other invocation keeps the table on stdout where a person reads it.
+ */
+const jsonToStdout = options.json === '-';
+const log = (line) => {
+  if (jsonToStdout) console.error(line);
+  else console.log(line);
+};
 
 const count = (value) => value.toLocaleString('en-US');
 const fixed = (value) =>
@@ -434,13 +490,13 @@ function table(rows, alignRight) {
 }
 
 function section(heading, rows, alignRight) {
-  console.log(`\n  ${heading}`);
+  log(`\n  ${heading}`);
   for (const line of table(rows, alignRight)) {
-    console.log(`    ${line}`);
+    log(`    ${line}`);
   }
 }
 
-console.log(
+log(
   `\n${LABEL}: ${count(files.length)} files, ${count(totalBytes)} bytes ` +
     `(${kib(totalBytes)} KiB) in out/`,
 );
@@ -494,7 +550,7 @@ section(
   new Set([1, 2, 3]),
 );
 
-console.log(
+log(
   `\n  inline SVG: ${count(inlineSvg.bytes)} bytes across ${count(inlineSvg.distinct)} ` +
     `distinct icons, ${count(inlineSvg.repeatedBytes)} of it repeat ` +
     `(widest spread: ${count(inlineSvg.widestSpread)} documents)`,
@@ -519,11 +575,11 @@ section(
 
 if (options.json) {
   const serialized = `${JSON.stringify(report, null, 2)}\n`;
-  if (options.json === '-') {
+  if (jsonToStdout) {
     process.stdout.write(serialized);
   } else {
     writeFileSync(resolve(ROOT, options.json), serialized);
-    console.log(`\n  wrote ${options.json}`);
+    log(`\n  wrote ${options.json}`);
   }
 }
 
@@ -534,9 +590,7 @@ if (options.updateBudget) {
     next[metric.id] = check.suggested;
   }
   writeFileSync(BUDGET_PATH, `${JSON.stringify(next, null, 2)}\n`);
-  console.log(
-    '\n  ratcheted scripts/budget.json to the measured sizes plus headroom',
-  );
+  log('\n  ratcheted scripts/budget.json to the measured sizes plus headroom');
   process.exit(0);
 }
 
@@ -559,4 +613,4 @@ if (exceeded.length > 0) {
 }
 
 const gated = checks.filter((check) => check.limit !== undefined).length;
-console.log(`\n${LABEL}: ${gated} budget(s) within limits\n`);
+log(`\n${LABEL}: ${gated} budget(s) within limits\n`);


### PR DESCRIPTION
Two Copilot comments on #935, both about `scripts/measure-export.mjs`. Both verified by running the script before changing it.

## 1. `--json -` did not produce parseable stdout

`--json -` is documented as machine-readable output, but the human table was printed to stdout ahead of it:

```
$ npm run measure-export -- --json - | jq .
Unexpected token 'm', "\nmeasure-ex"... is not valid JSON
```

The table now goes to **stderr**, and only when the JSON target is stdout.

Suppressing it was the other option, but stderr loses nothing: `--json - >report.json` still shows the table in the terminal, and the budget-failure text was already on stderr, so the whole human narrative ends up on one stream. `--json report.json` and the bare `npm run measure-export` that CI runs are untouched — a test pins each.

## 2. A budget key with a non-numeric value silently stopped gating

`limit: typeof limit === 'number' ? limit : undefined` folded every bad value into `undefined`, which is also how a metric is *deliberately* left ungated by omitting the key. So a limit accidentally committed as a string simply stopped gating, and the run still exited 0 announcing success. Measured on a fixture — the gate count falls silently and the exit code stays green:

| `cssBytes` | before | after |
| --- | --- | --- |
| `"1024"` | exit 0, **6** budgets gated | exit 1, named |
| `null` | exit 0, **6** budgets gated | exit 1, named |
| `true` | exit 0, **6** budgets gated | exit 1, named |
| `{"bytes":1024}` | exit 0, **6** budgets gated | exit 1, named |
| `1e999` | exit 0, **7 gated** — and unhittable | exit 1, named |
| `-1` | exit 1, but as a `-409700.0%` overage | exit 1, named |
| `1024.5` | exit 1, as an overage | exit 1, named |
| `0` | exit 1, real overage | unchanged — `0` stays legal |

`1e999` is the worst of them and was not in the review comment: JSON has no `Infinity` literal, but `1e999` parses into one, so the metric *reported itself as gated* while being incapable of ever failing.

Every known key must now be a whole number of bytes, 0 or greater. Anything else dies naming each offending key **and its value**, in the same shape as the existing unknown-key error:

```
measure-export: scripts/budget.json has invalid budget(s): cssBytes is null,
fontBytes is "1024", totalBytes is -1. Every budget must be a whole number of
bytes, 0 or greater.
```

`0` stays a legal budget — it is how a metric is held at nothing — and a test pins that so the rule cannot be tightened into rejecting it.

With validation in place the `typeof` coercion is gone, so an `undefined` limit once again means only what it is documented to mean: the key is absent.

## Also found while verifying

The same failure one level up, in the same function. A budget file whose root is `42` is valid JSON that declares no budgets at all — it gated nothing and **exited 0**. A root of `null` took `Object.keys` down with an uncaught stack trace. The root must now be a JSON object.

## Verification

- 17 tests added; `npx vitest run` is 956 passed (was 939 on the base).
- Each new test was checked by mutation — 8 mutations, every one killed: reverting the table to stdout, forcing the table to stderr unconditionally, deleting the invalid-value check, deleting the root-shape check, relaxing the predicate to `typeof value === 'number'`, tightening it to `> 0`, restoring the `typeof` coercion, and naming only the first offender.
- Run against a real `out/`: `--json -` parses, the committed `scripts/budget.json` passes the new rule, and all 7 gates are still enforced at 64–87% used.
- `npm run format`, `npx biome check .`, `npx tsc --noEmit` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
