### PR TITLE
fix(theme): stop the toggle docstring claiming a copied order cannot drift

### DIFF
--- a/src/components/Template/ThemeToggle.tsx
+++ b/src/components/Template/ThemeToggle.tsx
@@ -61,11 +61,16 @@ function labelFor(choice: ThemeChoice): string {
 }
 
 /**
- * Cycles system → light → dark → system, where `system` follows the device live.
+ * One button that cycles every theme choice, `system` included — and `system`
+ * follows the device live rather than sampling it once.
  *
- * That order is `nextThemeChoice`'s, not a copy of it: both the labels and the
- * rendered states below come out of `src/lib/theme.ts`, so this control cannot
- * end up describing an order it does not perform. `system` is the state a
+ * The order is deliberately not written out here. `THEME_CHOICES` and
+ * `nextThemeChoice` in `src/lib/theme.ts` hold it, and both the states rendered
+ * below and every label on them are read from those, so this control cannot
+ * perform an order other than the one it is given. A sequence written out in
+ * this comment could: it is prose, and nothing checks prose — an earlier
+ * version of this docstring spelled the cycle out and claimed, in the same
+ * sentence, that the spelling-out was not a copy. `system` is the state a
  * visitor who has never chosen starts in, and the one they can get back to.
  *
  * The rendered markup is deliberately identical for all three states: every

--- a/src/lib/__tests__/theme.test.ts
+++ b/src/lib/__tests__/theme.test.ts
@@ -153,6 +153,28 @@ describe('theme', () => {
     });
   });
 
+  describe('THEME_CHOICES', () => {
+    // Two literals hold one order: this array and the `nextThemeChoice` map.
+    // Nothing else notices when they disagree — the rendered states are picked
+    // by CSS from `data-theme-choice`, so their DOM order is unobservable, and
+    // reversing this array leaves every other test in the suite green.
+    it('is nextThemeChoice walked from the un-chosen state', () => {
+      // Nothing stored, per `beforeEach`: where a first-time visitor starts.
+      const start = readStoredThemeChoice();
+      expect(THEME_CHOICES[0]).toBe(start);
+
+      let cursor = start;
+      const walk: ThemeChoice[] = [cursor];
+
+      for (let step = 1; step < THEME_CHOICES.length; step += 1) {
+        cursor = nextThemeChoice(cursor);
+        walk.push(cursor);
+      }
+
+      expect(walk).toEqual([...THEME_CHOICES]);
+    });
+  });
+
   describe('resolveTheme', () => {
     it('ignores the device for an explicit choice', () => {
       expect(resolveTheme('light', 'dark')).toBe('light');

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -65,7 +65,18 @@ const NEXT_CHOICE: Record<ThemeChoice, ThemeChoice> = {
   dark: 'system',
 };
 
-/** Every choice, in cycle order starting from `system`. */
+/**
+ * Every choice, in cycle order, opening on the `system` a visitor who has never
+ * chosen is already in.
+ *
+ * The one place the order is written down: `ThemeToggle` iterates this and
+ * labels each state through {@link nextThemeChoice} rather than restating the
+ * sequence in prose, which is what its docstring used to do. This is still a
+ * second literal beside {@link NEXT_CHOICE}, so `theme.test.ts` walks
+ * `nextThemeChoice` from the un-chosen state and asserts the walk reproduces
+ * this array — reordering one and not the other is otherwise invisible, and
+ * was: the whole suite stayed green with this array reversed.
+ */
 export const THEME_CHOICES: readonly ThemeChoice[] = [
   'system',
   'light',


### PR DESCRIPTION
Fixes the review blocker on `src/components/Template/ThemeToggle.tsx:64-68`.

## The claim, reproduced

The docstring read:

> Cycles system → light → dark → system, where `system` follows the device live.
>
> That order is `nextThemeChoice`'s, not a copy of it: both the labels and the rendered states below come out of `src/lib/theme.ts`, so this control cannot end up describing an order it does not perform.

Confirmed as written. The second half is true of the *executable* parts — `labelFor` calls `nextThemeChoice`, and the states come from `THEME_CHOICES` — but the first line is a hand-typed duplicate of the order, sitting in the same docstring that says no duplicate exists. Nothing checks it. That sentence had already been rewritten a round earlier to fix a different inaccuracy, so it has now been wrong twice.

## Option (a): the sequence is gone

The docstring points at `THEME_CHOICES` and `nextThemeChoice` in `src/lib/theme.ts` and says why it does not restate the order, which makes the single-source claim true instead of merely asserted. Kept as a reader aid it would be the same liability with a disclaimer.

Behaviour untouched: same cycle, same accessible names, same markup. The diff is comments plus one test.

## The guard, and why it was needed

Pointing the prose at `THEME_CHOICES` only helps if `THEME_CHOICES` agrees with the cycle — and inside `theme.ts` the order is written down twice, once as the `NEXT_CHOICE` map and once as the array, with nothing tying them together.

Measured on the base branch:

```
# THEME_CHOICES reordered to ['system', 'dark', 'light']
Test Files  83 passed (83)
     Tests  964 passed (964)
```

Green, because CSS picks the visible state from `data-theme-choice` and the spans' DOM order is unobservable — every existing assertion is either order-independent or uses `THEME_CHOICES` only as a set and a length.

`src/lib/__tests__/theme.test.ts` now walks `nextThemeChoice` from the state an un-chosen visitor is in (`readStoredThemeChoice()` with storage cleared, so the test holds no literal order of its own) and asserts the walk reproduces the array.

Verified by mutation in both directions:

| Mutation | Result |
| --- | --- |
| `THEME_CHOICES` → `['system', 'dark', 'light']` | new test fails, and is the only failure |
| `NEXT_CHOICE` cycle reversed | new test fails, alongside the existing cycle test |
| neither | 965 pass |

## Definition of done

```
npm run format        clean
npx biome check .     Checked 224 files. No fixes applied.
npx tsc --noEmit      clean
npx vitest run        83 files, 965 passed (964 on base + 1 added)
```

Default reporter throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
