### PR TITLE
fix(stats): stop claiming no client JavaScript, and capitalise GitHub

### DIFF
--- a/src/components/Stats/Site.tsx
+++ b/src/components/Stats/Site.tsx
@@ -124,8 +124,25 @@ function measureThisBuild(): Record<string, Measurement> {
 }
 
 /**
- * Site statistics component - fetches GitHub data at build time.
- * Server component, no client-side JavaScript shipped.
+ * The site table: GitHub readings fetched at build time, beside everything this
+ * build can count about itself.
+ *
+ * A server component — but it used to claim "no client-side JavaScript shipped",
+ * and that stopped being true the moment the build clock arrived. What is true
+ * is narrower and more useful: beyond what the shared layout already ships, the
+ * client JavaScript on this page is two leaves, `<BuildClock>` here and
+ * `<LiveAge>` in the personal table, and both write their readings straight to a
+ * text node through `useLiveReadout`. Verified in the export rather than
+ * asserted: the only client references inside either table in
+ * `out/stats/index.txt` are those two, one per `<td>`, so every label, link,
+ * value, and provenance mark around them is server markup that no reading can
+ * re-render.
+ *
+ * Keep the boundary at the leaf. Last time a reading needed a client component
+ * the whole table followed it across — declarations, `resolveReadings`, `Table`,
+ * `TableRow` — and the export shipped `--.-----------` as the age to every
+ * crawler and every printed copy. `src/components/Stats/LiveAge.tsx` tells that
+ * story.
  */
 export default async function SiteStats() {
   // Started before the measurements so the file reads happen during the

--- a/src/components/__tests__/Stats/Site.test.tsx
+++ b/src/components/__tests__/Stats/Site.test.tsx
@@ -49,9 +49,9 @@ describe('Site', () => {
     render(Component);
 
     expect(
-      screen.getByText('Stars this repository has on github'),
+      screen.getByText('Stars this repository has on GitHub'),
     ).toBeInTheDocument();
-    expect(screen.getByText('Number of forks')).toBeInTheDocument();
+    expect(screen.getByText('Forks of this repository')).toBeInTheDocument();
     expect(screen.getByText('Number of spoons')).toBeInTheDocument();
   });
 
@@ -83,17 +83,38 @@ describe('Site', () => {
     render(Component);
 
     expect(
-      screen.getByText('Stars this repository has on github'),
+      screen.getByText('Stars this repository has on GitHub'),
     ).toBeInTheDocument();
     expect(
-      screen.getByText('Number of people watching this repository'),
+      screen.getByText('People watching this repository'),
     ).toBeInTheDocument();
-    expect(screen.getByText('Number of forks')).toBeInTheDocument();
+    expect(screen.getByText('Forks of this repository')).toBeInTheDocument();
     expect(
-      screen.getByText('Open github issues and pull requests'),
+      screen.getByText('Issues and pull requests open on GitHub'),
     ).toBeInTheDocument();
     expect(
       screen.getByText('Last push to this repository'),
+    ).toBeInTheDocument();
+  });
+
+  it('spells the brand GitHub everywhere the page says it', async () => {
+    // `Stars this repository has on github` and `Open github issues and pull
+    // requests` were the only lowercase brand in the entire export, on the one
+    // page that is entirely about a GitHub repository. Case-sensitive on
+    // purpose: `/github/i` passes against the bug.
+    const Component = await Site();
+    const { container } = render(Component);
+
+    for (const element of container.querySelectorAll(
+      '.stat-table-label-text, .stats-source-note',
+    )) {
+      expect(element.textContent, element.textContent ?? '').not.toContain(
+        'github',
+      );
+    }
+    // The URLs are untouched — only the copy changes.
+    expect(
+      container.querySelector('a[href*="github.com"]'),
     ).toBeInTheDocument();
   });
 

--- a/src/data/__tests__/stats/site.test.ts
+++ b/src/data/__tests__/stats/site.test.ts
@@ -152,6 +152,40 @@ describe('site stats data', () => {
     }
   });
 
+  it('spells the brand GitHub in every label', () => {
+    // Case-sensitive, because a case-insensitive assertion passes against the
+    // bug: `Stars this repository has on github` and `Open github issues and
+    // pull requests` both shipped, and they were the only lowercase brand in
+    // the export.
+    for (const stat of data) {
+      expect(stat.label, stat.label).not.toContain('github');
+    }
+
+    // The keys and URLs keep the API's and the web's own spelling.
+    expect(data.some((s) => s.label.includes('GitHub'))).toBe(true);
+    expect(data.some((s) => s.key === 'stargazers_count')).toBe(true);
+  });
+
+  it('names the fact rather than counting it, except in the joke', () => {
+    // `Number of forks` was the `forks` API key with `Number of` bolted on: it
+    // named the field, not the fact, and never said what had been forked. The
+    // value column is a number on every row, so the prefix told a reader
+    // nothing. The joke keeps it — a deadpan inventory line is the punchline.
+    const counted = data
+      .filter((s) => s.label.startsWith('Number of'))
+      .map((s) => s.label);
+
+    expect(counted).toEqual(['Number of spoons']);
+  });
+
+  it('does not open a label with a verb a reader could obey', () => {
+    // `Open github issues and pull requests` put an imperative at the head of a
+    // table row, which is exactly where a control's label sits.
+    for (const stat of data) {
+      expect(stat.label, stat.label).not.toMatch(/^(Open|Click|View|See)\b/);
+    }
+  });
+
   it('units appear only where the label does not already name them', () => {
     for (const stat of data.filter((s) => s.unit)) {
       expect(stat.label.toLowerCase(), stat.label).not.toContain(

--- a/src/data/stats/site.ts
+++ b/src/data/stats/site.ts
@@ -5,9 +5,9 @@ const REPO = 'https://github.com/mldangelo/personal-site';
 const BLOB = `${REPO}/blob/main`;
 
 /* Keys are filled in by `src/components/Stats/Site.tsx`: `source: 'github'`
- * rows match keys returned by the GitHub api, `source: 'measured'` rows are
+ * rows match keys returned by the GitHub API, `source: 'measured'` rows are
  * counted from the working tree at build time. To see everything returned by
- * the github api, run:
+ * the GitHub API, run:
  curl https://api.github.com/repos/mldangelo/personal-site
  *
  * Never type a figure about this codebase into this file. A `measured` row
@@ -16,22 +16,35 @@ const BLOB = `${REPO}/blob/main`;
  * count drifted by nearly 2,000 lines, and `Number of linter warnings: '0'`
  * carried the comment "enforced via github workflow" four lines below the
  * warning against exactly that.
+ *
+ * Two rules about the labels, both of which shipped broken:
+ *
+ * - The brand is `GitHub`. `Stars this repository has on github` and `Open
+ *   github issues and pull requests` were the only lowercase brand in the whole
+ *   export, sitting on the one page that is entirely about a GitHub repository.
+ *   The keys are the API's spelling and stay as they are; only the copy changes.
+ *   The lowercase quotation above is deliberate — it is a deleted comment quoted
+ *   verbatim, and `src/lib/manifest.ts` quotes the same string.
+ * - A label names the fact, not the field, and does not restate that the value
+ *   is a number — the right-hand column is a number on every row. `Number of
+ *   forks` was the `forks` key with `Number of` bolted on and never said what
+ *   had been forked. The joke row keeps the form on purpose; see the bottom.
  */
 const data: StatDeclaration[] = [
   {
-    label: 'Stars this repository has on github',
+    label: 'Stars this repository has on GitHub',
     key: 'stargazers_count',
     source: 'github',
     link: `${REPO}/stargazers`,
   },
   {
-    label: 'Number of people watching this repository',
+    label: 'People watching this repository',
     key: 'subscribers_count',
     source: 'github',
     link: `${REPO}/watchers`,
   },
   {
-    label: 'Number of forks',
+    label: 'Forks of this repository',
     key: 'forks',
     source: 'github',
     link: `${REPO}/network`,
@@ -39,7 +52,12 @@ const data: StatDeclaration[] = [
   {
     // GitHub's open_issues_count includes open pull requests, so the label
     // says what the number actually counts rather than overstating issues.
-    label: 'Open github issues and pull requests',
+    //
+    // The nouns lead. `Open github issues and pull requests` put an imperative
+    // verb at the head of a table row — exactly where a control's label sits —
+    // so it read as an instruction to go and open some, and `Open` is the word
+    // doing the work in the count.
+    label: 'Issues and pull requests open on GitHub',
     key: 'open_issues_count',
     source: 'github',
     link: 'https://github.com/search?q=repo%3Amldangelo%2Fpersonal-site+is%3Aopen&type=issues',
@@ -125,6 +143,10 @@ const data: StatDeclaration[] = [
     // The joke, and the only row on the page that measures nothing — so it is
     // the only row with no provenance mark. Last, because it reads better as a
     // punchline than as an interruption.
+    //
+    // The only surviving `Number of`, and deliberately so: the deadpan
+    // inventory phrasing is the joke, and it lands because every real row above
+    // it has dropped the form.
     label: 'Number of spoons',
     value: 0,
   },


### PR DESCRIPTION
Owner's cleanup 2 on the integration branch: `src/components/Stats/Site.tsx:126-129` still said "no client-side JavaScript shipped" although this branch renders the `BuildClock` client leaf, and the public labels still lowercased the GitHub brand.

Both claims reproduced against a real build before changing anything.

## 1. The doc comment was false

`SiteStats` documented itself as "Server component, no client-side JavaScript shipped" three lines above `<BuildClock builtAt={builtAt} …/>`, a `'use client'` component. `/stats` also carries `<LiveAge>` in the personal table.

Rather than deleting the claim, the comment now states the property that is actually true and worth defending, verified rather than asserted. From `out/stats/index.txt`, the client references bundled into the stats page chunk are:

| ref | module | where it appears |
| --- | --- | --- |
| `$Le` | `LiveAge` | one `<td class="stat-table-value">`, props `{initial, note, precision}` |
| `$L22` | `BuildClock` | one `<td class="stat-table-value">`, props `{builtAt, initial}` |
| `$L7` | `next/link` | footer and not-found only — nothing in either table |

Everything else in both tables — `<tr>`/`<th>`/`<td>`, every label, link, formatted value, and provenance mark — is plain server markup in the flight payload. Both leaves write through `useLiveReadout`, which assigns to `textContent`, so a ticking reading re-renders nothing. The comment says exactly that, and says to keep the boundary at the leaf, because the last time a reading needed a client component the whole table followed it across and the export shipped `--.-----------` as the age.

## 2. The brand, and three other copy problems

A tag-stripped scan of the whole export found the site's only lowercase visible brand on `/stats` — both labels — the one page that is entirely about a GitHub repository. (`github.com/mldangelo` on `/resume` is a URL and stays.)

| before | after | why |
| --- | --- | --- |
| `Stars this repository has on github` | `Stars this repository has on GitHub` | brand |
| `Open github issues and pull requests` | `Issues and pull requests open on GitHub` | brand, plus the garden path: an imperative verb at the head of a table row is exactly where a control's label sits, so it read as an instruction to go and open some rather than as a count |
| `Number of forks` | `Forks of this repository` | the `forks` API key with `Number of` bolted on — it named the field, not the fact, and never said what had been forked |
| `Number of people watching this repository` | `People watching this repository` | the value column is a number on every row, so the prefix said nothing |

Keys (`stargazers_count`, `open_issues_count`, `pushed_at`, `forks`) and every URL are untouched; the one lowercase `github` left in the file is a deleted comment quoted verbatim, which `src/lib/manifest.ts` quotes too, and the comment now says so.

`Number of spoons` keeps the form deliberately: the deadpan inventory line is the joke, and it lands because every real row above it has dropped it.

## Tests

Six existing assertions updated to the new labels, and three new pins — each confirmed red with the label change stashed, so none of them is documentation:

- no lowercase `github` in any label, or in either rendered source note. Case-sensitive on purpose: `/github/i` passes against the bug.
- `Number of` survives on the joke row and nowhere else.
- no label opens with `Open` / `Click` / `View` / `See`.

## Verification

- `npm run format` clean, `npx biome check .` clean (224 files), `npx tsc --noEmit` clean.
- `npx vitest run` (default reporter): **968 passed / 83 files**, against 964 on the base — the four added.
- `npm run build` green before and after; re-read `out/stats/index.html` and `out/stats/index.txt` to confirm the fifteen rendered labels, the brand casing, and the two-client-reference structure the new comment describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
