### PR TITLE
fix: derive the site-wide current role instead of reading work[0]

### DIFF
--- a/src/components/Template/Footer.tsx
+++ b/src/components/Template/Footer.tsx
@@ -2,13 +2,15 @@ import Link from 'next/link';
 
 import ContactIcons from '@/components/Contact/ContactIcons';
 import work from '@/data/resume/work';
+import { currentPosition } from '@/lib/career';
 import routes from '@/data/routes';
 import { AUTHOR_NAME } from '@/lib/utils';
 
 import ThemePortrait from './ThemePortrait';
 
 export default function Footer() {
-  const currentRole = `${work[0].position} at ${work[0].name}`;
+  const current = currentPosition(work);
+  const currentRole = current ? `${current.position} at ${current.name}` : null;
 
   return (
     <footer className="site-footer-new">

--- a/src/lib/__tests__/career.test.ts
+++ b/src/lib/__tests__/career.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import type { Position } from '@/data/resume/work';
 import work from '@/data/resume/work';
 import {
+  currentPosition,
   formatDuration,
   monthsBetween,
   positionDuration,
@@ -321,5 +322,63 @@ describe('totalExperienceYears', () => {
     expect(totalExperienceYears(work, laterYear)).toBe(
       totalExperienceYears(work, NOW) + 1,
     );
+  });
+});
+
+describe('currentPosition', () => {
+  it('names the ongoing full-time role, not the first in the array', () => {
+    expect(currentPosition(work)?.name).toBe('OpenAI');
+  });
+
+  it('is independent of source order', () => {
+    // The property `schema.ts` and `Footer.tsx` used to depend on by accident:
+    // appending or reordering entries must not change the site-wide employer.
+    const reversed = [...work].reverse();
+
+    expect(currentPosition(reversed)?.name).toBe(currentPosition(work)?.name);
+  });
+
+  it('skips an ongoing part-time role in favour of the full-time one', () => {
+    const chosen = currentPosition([
+      position({
+        name: 'Side Fund',
+        startDate: '2017-04-01',
+        endDate: undefined,
+        commitment: 'part-time',
+      }),
+      position({
+        name: 'Day Job',
+        startDate: '2024-01-01',
+        endDate: undefined,
+      }),
+    ]);
+
+    expect(chosen?.name).toBe('Day Job');
+  });
+
+  it('prefers the newest start when two full-time roles are both ongoing', () => {
+    const chosen = currentPosition([
+      position({ name: 'Older', startDate: '2020-01-01', endDate: undefined }),
+      position({ name: 'Newer', startDate: '2026-03-09', endDate: undefined }),
+    ]);
+
+    expect(chosen?.name).toBe('Newer');
+  });
+
+  it('falls back to the most recently ended role when nothing is ongoing', () => {
+    const chosen = currentPosition([
+      position({ name: 'Old', startDate: '2014-01-01', endDate: '2016-01-01' }),
+      position({
+        name: 'Recent',
+        startDate: '2018-01-01',
+        endDate: '2022-01-01',
+      }),
+    ]);
+
+    expect(chosen?.name).toBe('Recent');
+  });
+
+  it('returns undefined for an empty list rather than throwing', () => {
+    expect(currentPosition([])).toBeUndefined();
   });
 });

--- a/src/lib/career.ts
+++ b/src/lib/career.ts
@@ -163,3 +163,30 @@ export function totalExperienceYears(
 
   return Math.floor(monthsBetween(earliestStart, now) / 12);
 }
+
+/**
+ * The role to describe as current in site-wide copy: the JSON-LD `jobTitle` and
+ * `worksFor`, and the footer's one-line identity.
+ *
+ * `schema.ts` and `Footer.tsx` both used to read `work[0]` off the raw array.
+ * That was correct only because the newest role happens to be written first,
+ * and this module's own docstring had just declared source order *not*
+ * load-bearing — a new entry appended anywhere was documented as safe, and
+ * would silently have rewritten the site's JSON-LD employer and the footer of
+ * every page.
+ *
+ * "Current" is derived rather than positional: the ongoing role — no `endDate`
+ * — that is somebody's actual job, newest start first. `commitment:
+ * 'part-time'` is excluded deliberately, for the same reason it does not lead
+ * the resume spine: an angel fund running alongside a full-time post is not the
+ * answer to "where does he work". If nothing is ongoing, the most recently
+ * ended role stands in, so this never returns `undefined` for a non-empty list
+ * and callers need no fallback branch.
+ */
+export function currentPosition(positions: Position[]): Position | undefined {
+  const ongoingFullTime = positions
+    .filter((entry) => !entry.endDate && entry.commitment !== 'part-time')
+    .sort((a, b) => b.startDate.localeCompare(a.startDate));
+
+  return ongoingFullTime[0] ?? sortPositions(positions)[0];
+}

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -1,6 +1,7 @@
 import contact from '@/data/contact';
 import degrees from '@/data/resume/degrees';
 import work from '@/data/resume/work';
+import { currentPosition } from '@/lib/career';
 import type { Post } from '@/lib/posts';
 import {
   AUTHOR_NAME,
@@ -65,7 +66,9 @@ export function personNode(): SchemaNode {
   const emailItem = contact.find((item) => item.link.startsWith('mailto:'));
   const email = emailItem?.link.replace('mailto:', '');
 
-  const currentJob = work[0];
+  // Derived, not positional — see `currentPosition`. Reading `work[0]` tied the
+  // site-wide employer to the order of a hand-maintained file.
+  const currentJob = currentPosition(work);
 
   const [givenName, ...familyParts] = AUTHOR_NAME.split(' ');
   const familyName = familyParts.join(' ');
@@ -86,14 +89,21 @@ export function personNode(): SchemaNode {
       caption: AUTHOR_NAME,
     },
     description: SITE_DESCRIPTION,
-    jobTitle: currentJob.position,
+    // Omitted rather than emitted empty when there is no current role. A
+    // `jobTitle` of `undefined` or a nameless `worksFor` is worse than absent
+    // structured data: consumers treat a present-but-blank field as a claim.
+    // `work[0]` never needed this branch only because indexing an array is
+    // untyped, not because the case could not arise.
+    ...(currentJob && { jobTitle: currentJob.position }),
     ...(email && { email }),
     sameAs: socialLinks,
-    worksFor: {
-      '@type': 'Organization',
-      name: currentJob.name,
-      url: currentJob.url,
-    },
+    ...(currentJob && {
+      worksFor: {
+        '@type': 'Organization',
+        name: currentJob.name,
+        url: currentJob.url,
+      },
+    }),
     alumniOf: degrees.map((degree) => ({
       '@type': 'CollegeOrUniversity',
       name: degree.school,


### PR DESCRIPTION
`schema.ts:68` and `Footer.tsx:11` both read the current employer from `work[0]`
off the raw array. That was only correct because the newest role happens to be
written first — and this branch had just documented, in two places, that source
order is **not** load-bearing and a new entry may be appended anywhere.
Following our own guidance would have silently rewritten the site's JSON-LD
employer and the footer of every page.

`currentPosition` in `src/lib/career.ts` derives it: the ongoing role (no
`endDate`) that is somebody's actual job, newest start first, with
`commitment: 'part-time'` excluded for the same reason it does not lead the
spine. Falls back to the most recently ended role.

## Two things the old code was hiding

- `work[0]` type-checked as non-undefined only because array indexing is
  untyped, so `personNode` never handled an empty list. `jobTitle` and
  `worksFor` are now **omitted** rather than emitted blank — a
  present-but-empty structured-data field reads as a claim.
- Nothing tested that the site-wide employer was independent of source order.
  Reversing `work` would not have failed a single assertion.

## Verification

- 970 tests pass (964 on base + 6).
- Mutation-verified: restoring `positions[0]` fails 4 of the new tests.
- Rendered output unchanged today — `work[0]` is OpenAI either way, which is
  exactly why this was invisible.

Found by re-running an audit whose verification pass had died on network
errors, leaving the finding unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)