### PR TITLE
fix(writing): route internal Markdown links through Next navigation

### DIFF
--- a/app/styles/__tests__/stylesheets.test.ts
+++ b/app/styles/__tests__/stylesheets.test.ts
@@ -133,8 +133,18 @@ describe('stylesheet graph', () => {
 // The honest version — view-transition CSS must be accompanied by something
 // that can start a transition — would have passed the file that motivated the
 // guard: deleted `utilities.css` declared its own `@view-transition
-// { navigation: auto }` trigger. What was actually wrong with it was
-// app-specific (every internal link here goes through `<Link>`, so no
-// same-origin cross-document navigation occurs), and that is a fact about this
-// app's routing, not a rule a stylesheet-graph test can hold. `app/tailwind.css`
-// records it as a comment instead.
+// { navigation: auto }` trigger. What was actually wrong with it is
+// app-specific, a fact about this app's routing rather than a rule a
+// stylesheet-graph test can hold, so `app/tailwind.css` records it as a
+// comment instead.
+//
+// That routing fact was overstated when it was first written here. It said
+// every internal link goes through `<Link>`, while Markdown prose still
+// rendered native anchors — `[Good design](/)` in `src/data/about.ts` exported
+// a literal `<a href="/">` from `/about/`, which is precisely the same-origin
+// cross-document navigation the deleted rule could have run for.
+// `src/lib/markdownLinks.tsx` routes internal Markdown links through `<Link>`
+// as well now, and `src/lib/__tests__/markdownLinks.test.tsx` pins the
+// classification. What is left native and same-origin is links to exported
+// files — `/feed.xml`, `/resume.json`, `/og.png` — and a navigation to one of
+// those has no document on the other side to opt in.

--- a/src/components/About/Sections.tsx
+++ b/src/components/About/Sections.tsx
@@ -4,6 +4,7 @@ import Markdown from 'markdown-to-jsx';
 import { Children, type ReactNode } from 'react';
 import { createUniqueHeadingIds } from '@/lib/anchors';
 import { extractLogMarker } from '@/lib/logEntry';
+import { PROSE_LINK_OVERRIDES } from '@/lib/markdownLinks';
 
 interface AboutContentProps {
   markdown: string;
@@ -52,8 +53,16 @@ function LogEntry({ children }: { children?: ReactNode }) {
   );
 }
 
+/**
+ * Every block here is prose, so every block routes its internal links; the log
+ * sections additionally file each entry in the gutter.
+ */
+const MARKDOWN_OPTIONS = {
+  overrides: PROSE_LINK_OVERRIDES,
+};
+
 const LOG_MARKDOWN_OPTIONS = {
-  overrides: { li: { component: LogEntry } },
+  overrides: { ...PROSE_LINK_OVERRIDES, li: { component: LogEntry } },
 };
 
 interface AboutSection {
@@ -150,7 +159,7 @@ export default function AboutContent({ markdown }: AboutContentProps) {
     <article className="about-content">
       {intro ? (
         <div className="about-intro">
-          <Markdown>{intro}</Markdown>
+          <Markdown options={MARKDOWN_OPTIONS}>{intro}</Markdown>
         </div>
       ) : null}
       {sections.length > 0 ? (
@@ -182,7 +191,7 @@ export default function AboutContent({ markdown }: AboutContentProps) {
           {isLogSection(section.title) ? (
             <Markdown options={LOG_MARKDOWN_OPTIONS}>{section.body}</Markdown>
           ) : (
-            <Markdown>{section.body}</Markdown>
+            <Markdown options={MARKDOWN_OPTIONS}>{section.body}</Markdown>
           )}
         </section>
       ))}

--- a/src/components/About/__tests__/Sections.test.tsx
+++ b/src/components/About/__tests__/Sections.test.tsx
@@ -1,10 +1,21 @@
 import { render, screen, waitFor, within } from '@testing-library/react';
+import type { ComponentPropsWithoutRef } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { aboutMarkdown } from '@/data/about';
 import { createHeadingId } from '@/lib/anchors';
 import AboutContent from '../Sections';
+
+// `<Link>` renders a plain `<a>`, so nothing in the DOM distinguishes a
+// client-routed link from one that reloads the document. The mock marks it.
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...rest }: ComponentPropsWithoutRef<'a'>) => (
+    <a data-router-link="true" href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
 
 function getActualSectionTitles(markdown: string) {
   return Array.from(markdown.matchAll(/^# (.+)$/gm))
@@ -166,6 +177,60 @@ Lead paragraph.
     for (const marker of empty) {
       expect(marker.querySelector('.log-entry-year')).toBeNull();
     }
+  });
+
+  it('routes the internal link the real prose carries, and leaves the rest native', () => {
+    render(<AboutContent markdown={aboutMarkdown} />);
+
+    // `- [Good design](/).` in `src/data/about.ts`, which shipped as a native
+    // anchor and reloaded the document from a fully client-routed page.
+    const internal = screen.getByRole('link', { name: 'Good design' });
+
+    expect(internal).toHaveAttribute('data-router-link', 'true');
+    expect(internal).toHaveAttribute('href', '/');
+    // No opt-out class: `.about-content a` is what underlines a prose link.
+    expect(internal).not.toHaveAttribute('class');
+
+    const external = screen.getByRole('link', { name: 'OpenAI' });
+
+    expect(external).not.toHaveAttribute('data-router-link');
+    expect(external).toHaveAttribute('href', 'https://openai.com');
+  });
+
+  it('routes internal links from the intro, a log section, and a plain section', () => {
+    render(
+      <AboutContent
+        markdown={`# Intro
+
+Start at the [home page](/).
+
+# Some History
+
+- At 10, I built a [terrible site](/projects) with FrontPage.
+
+# I Like
+
+- [Good design](/).
+- [Books](https://www.goodreads.com/mdangelo).`}
+      />,
+    );
+
+    const routed: [string, string][] = [
+      ['home page', '/'],
+      ['terrible site', '/projects/'],
+      ['Good design', '/'],
+    ];
+
+    for (const [name, href] of routed) {
+      const link = screen.getByRole('link', { name });
+
+      expect(link, name).toHaveAttribute('data-router-link', 'true');
+      expect(link, name).toHaveAttribute('href', href);
+    }
+
+    expect(screen.getByRole('link', { name: 'Books' })).not.toHaveAttribute(
+      'data-router-link',
+    );
   });
 
   it('supports same-page hash navigation from section links', async () => {

--- a/src/components/Writing/PostContent.tsx
+++ b/src/components/Writing/PostContent.tsx
@@ -6,6 +6,7 @@ import type { ReactNode } from 'react';
 import { Children, type CSSProperties, isValidElement } from 'react';
 
 import { createHeadingId, planHeadingAliases } from '@/lib/anchors';
+import { PROSE_LINK_OVERRIDES } from '@/lib/markdownLinks';
 
 interface ImageSize {
   width: number;
@@ -174,6 +175,10 @@ export default function PostContent({
         // the site derived `on-using-dangerously-skip-permissions`.
         slugify: createHeadingId,
         overrides: {
+          // A post that links to another post is an internal navigation like
+          // any other, so it goes through the router rather than reloading the
+          // document.
+          ...PROSE_LINK_OVERRIDES,
           // Unifying the scheme renamed ids that were already published, so
           // each heading also carries whatever id it used to have.
           ...headingOverrides(aliases),

--- a/src/components/Writing/__tests__/PostContent.test.tsx
+++ b/src/components/Writing/__tests__/PostContent.test.tsx
@@ -1,11 +1,22 @@
+import type { ComponentPropsWithoutRef } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { createHeadingId } from '@/lib/anchors';
 import { readPostImageSizes } from '@/lib/imageSize';
 import { getAllPosts, getPostBySlug } from '@/lib/posts';
 
 import PostContent from '../PostContent';
+
+// `<Link>` renders a plain `<a>`, so nothing in the markup distinguishes a
+// client-routed link from one that reloads the document. The mock marks it.
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...rest }: ComponentPropsWithoutRef<'a'>) => (
+    <a data-router-link="true" href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
 
 const OG_SIZE = { '/og.png': { width: 1200, height: 630 } };
 
@@ -121,6 +132,72 @@ describe('PostContent figures', () => {
     );
 
     expect(html).toContain('--figure-width:1117px');
+  });
+});
+
+describe('PostContent links', () => {
+  it('routes a link to another post through the router', () => {
+    const html = renderToStaticMarkup(
+      <PostContent
+        content={
+          'I wrote about [shipping with Claude Code](/writing/shipping-with-claude-code/).\n'
+        }
+      />,
+    );
+
+    expect(html).toContain(
+      '<a data-router-link="true" href="/writing/shipping-with-claude-code/">',
+    );
+  });
+
+  it('normalises a route the author wrote without its trailing slash', () => {
+    const html = renderToStaticMarkup(
+      <PostContent content={'See the [résumé](/resume#skills).\n'} />,
+    );
+
+    expect(html).toContain('href="/resume/#skills"');
+  });
+
+  it('leaves an off-site link, a scheme, and a fragment native', () => {
+    const html = renderToStaticMarkup(
+      <PostContent
+        content={
+          'Read [the announcement](https://openai.com/index/codex-security-now-in-research-preview/), [email me](mailto:hello@example.com), or jump to [the layers](#verification-layers).\n'
+        }
+      />,
+    );
+
+    expect(html).not.toContain('data-router-link');
+    expect(html).toContain(
+      '<a href="https://openai.com/index/codex-security-now-in-research-preview/">',
+    );
+    expect(html).toContain('<a href="mailto:hello@example.com">');
+    expect(html).toContain('<a href="#verification-layers">');
+  });
+
+  it('leaves an exported file to the host rather than the router', () => {
+    const html = renderToStaticMarkup(
+      <PostContent
+        content={'Grab [the feed](/feed.xml) or [the card](/og.png).\n'}
+      />,
+    );
+
+    expect(html).not.toContain('data-router-link');
+    expect(html).toContain('<a href="/feed.xml">');
+    expect(html).toContain('<a href="/og.png">');
+  });
+
+  it('routes a linked figure without costing it its figure', () => {
+    const html = renderToStaticMarkup(
+      <PostContent
+        content={'Intro.\n\n[![Alt](/og.png "The card")](/writing/)\n'}
+        imageSizes={OG_SIZE}
+      />,
+    );
+
+    expect(html).toContain('<figure class="prose-figure"');
+    expect(html).toContain('<a data-router-link="true" href="/writing/">');
+    expect(html).toContain('The card</figcaption>');
   });
 });
 

--- a/src/lib/__tests__/markdownLinks.test.tsx
+++ b/src/lib/__tests__/markdownLinks.test.tsx
@@ -1,0 +1,145 @@
+import Link from 'next/link';
+import type { ComponentPropsWithoutRef, ReactElement } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { markdownRouteHref, ProseLink } from '@/lib/markdownLinks';
+import { SITE_URL } from '@/lib/utils';
+
+/**
+ * `ProseLink` is a pure function of its props, so calling it returns the
+ * element it chose. Asserting on the element's `type` names the component
+ * directly — `next/link` renders a plain `<a>` into the DOM, so nothing in the
+ * rendered markup can tell the two branches apart.
+ */
+function chosen(props: ComponentPropsWithoutRef<'a'>) {
+  const element = ProseLink(props) as ReactElement<
+    ComponentPropsWithoutRef<'a'>
+  >;
+
+  return { type: element.type, props: element.props };
+}
+
+describe('markdownRouteHref', () => {
+  it('routes internal paths, normalised to the exported trailing slash', () => {
+    const cases: [string, string][] = [
+      ['/', '/'],
+      ['/about', '/about/'],
+      ['/about/', '/about/'],
+      [
+        '/writing/shipping-with-claude-code/',
+        '/writing/shipping-with-claude-code/',
+      ],
+      // A route whose own segment holds a dot is still a route: the trailing
+      // slash is what separates a route from a file.
+      ['/writing/claude.md-notes/', '/writing/claude.md-notes/'],
+    ];
+
+    for (const [href, route] of cases) {
+      expect(markdownRouteHref(href), href).toBe(route);
+    }
+  });
+
+  it('keeps a fragment and a query on the routed href', () => {
+    expect(markdownRouteHref('/writing/post#verification-layers')).toBe(
+      '/writing/post/#verification-layers',
+    );
+    expect(markdownRouteHref('/writing?tag=agents')).toBe(
+      '/writing/?tag=agents',
+    );
+  });
+
+  it('routes an absolute URL that addresses this site', () => {
+    expect(markdownRouteHref(`${SITE_URL}/about`)).toBe('/about/');
+    expect(markdownRouteHref(SITE_URL)).toBe('/');
+  });
+
+  it('leaves an exported file to the host rather than the router', () => {
+    for (const href of [
+      '/feed.xml',
+      '/sitemap.xml',
+      '/resume.json',
+      '/og.png',
+      '/OG.PNG',
+      '/images/writing/api-costs-july-2025.png',
+      `${SITE_URL}/feed.xml`,
+    ]) {
+      expect(markdownRouteHref(href), href).toBeNull();
+    }
+  });
+
+  it('leaves everything that is not a same-origin route native', () => {
+    for (const href of [
+      // Same-document scroll, not a navigation.
+      '#some-history',
+      'mailto:michael@example.com',
+      'tel:+15551234567',
+      'https://example.com/',
+      'https://example.com/about',
+      // Protocol-relative, which shares its prefix with a rooted path.
+      '//example.com/about',
+      // The URL parser reads a leading `/\` as an authority too, so a rooted
+      // path is not automatically same-origin.
+      '/\\evil.com/about',
+      // Same host, but not the canonical origin.
+      'http://mldangelo.com/about',
+      // Relative references: the browser resolves these against the document
+      // URL, and nothing in the site's prose writes one.
+      'sibling/page/',
+      '../other/',
+      './same/',
+      '',
+      undefined,
+    ]) {
+      expect(markdownRouteHref(href), String(href)).toBeNull();
+    }
+  });
+});
+
+describe('ProseLink', () => {
+  it('hands an internal href to next/link as a normalised route', () => {
+    const internal = chosen({ href: '/', children: 'Good design' });
+
+    expect(internal.type).toBe(Link);
+    expect(internal.props.href).toBe('/');
+    expect(internal.props.children).toBe('Good design');
+
+    expect(chosen({ href: '/writing/post' }).props.href).toBe('/writing/post/');
+  });
+
+  it('leaves an external href a native anchor, byte for byte', () => {
+    const external = chosen({ href: 'https://openai.com', children: 'OpenAI' });
+
+    expect(external.type).toBe('a');
+    expect(external.props.href).toBe('https://openai.com');
+    expect(external.props.children).toBe('OpenAI');
+  });
+
+  it('carries a Markdown title through either branch', () => {
+    expect(chosen({ href: '/about', title: 'About me' }).props.title).toBe(
+      'About me',
+    );
+    expect(
+      chosen({ href: 'https://example.com', title: 'Example' }).props.title,
+    ).toBe('Example');
+  });
+
+  it('adds no class to either branch, so prose links keep their underline', () => {
+    // `app/styles/base/links.css` paints the accent underline on `p a`;
+    // per AGENTS.md only navigation-like links opt out of it.
+    expect(chosen({ href: '/about' }).props.className).toBeUndefined();
+    expect(
+      chosen({ href: 'https://example.com' }).props.className,
+    ).toBeUndefined();
+  });
+
+  it('keeps a new-tab affordance an author supplied', () => {
+    const external = chosen({
+      href: 'https://example.com',
+      target: '_blank',
+      rel: 'noopener noreferrer',
+    });
+
+    expect(external.props.target).toBe('_blank');
+    expect(external.props.rel).toBe('noopener noreferrer');
+  });
+});

--- a/src/lib/markdownLinks.tsx
+++ b/src/lib/markdownLinks.tsx
@@ -1,0 +1,115 @@
+/**
+ * Markdown link routing: which prose links the App Router should intercept.
+ *
+ * Every hand-written link to a route goes through `next/link` — the only native
+ * internal anchors are fragments and `/feed.xml` — but Markdown link syntax
+ * does not: `markdown-to-jsx` renders a native `<a>`, so `[Good design](/)` in
+ * `src/data/about.ts` shipped a same-origin cross-document navigation from a
+ * page that is otherwise entirely client-routed. A full document load is slower
+ * than a client navigation and it throws away scroll restoration.
+ *
+ * Both prose surfaces (`About/Sections`, `Writing/PostContent`) share this one
+ * override, so the classification cannot drift between them.
+ */
+import Link from 'next/link';
+import type { ComponentPropsWithoutRef } from 'react';
+
+import { SITE_URL } from './utils';
+
+const SITE_ORIGIN = new URL(SITE_URL).origin;
+
+/**
+ * A final path segment carrying an extension — `/feed.xml`, `/resume.json`,
+ * `/og.png`. `trailingSlash: true` means every *route* in the export ends in a
+ * slash, so a last segment with a dot in it is a file the host serves
+ * directly, not something the router can navigate to.
+ */
+const FILE_SEGMENT = /\.[a-z0-9]+$/i;
+
+/**
+ * The route to hand `next/link`, or `null` when the link must stay a native
+ * `<a>`.
+ *
+ * Internal means same-origin and addressable by the router: a rooted path, or
+ * an absolute URL naming this site. Those come back rooted and
+ * slash-normalised, because `trailingSlash: true` makes `/about/` the
+ * canonical form and prose writes both spellings.
+ *
+ * Everything else stays native, and `internalUrl` is where each case is
+ * decided: an off-site URL, a protocol-relative `//host/path`, a `mailto:` or
+ * `tel:` (or any other scheme, which has no origin to match), a bare
+ * `#fragment` — a same-document scroll rather than a navigation — and a
+ * relative reference such as `sibling/` or `../other/`. The browser resolves a
+ * relative reference against the document URL and the router would resolve it
+ * against the current route; rather than reason about whether those agree
+ * under `trailingSlash: true`, they are left to the browser. Nothing in
+ * `content/writing/` or `src/data` writes one.
+ */
+export function markdownRouteHref(href: string | undefined): string | null {
+  if (!href) {
+    return null;
+  }
+
+  const url = internalUrl(href);
+  if (!url) {
+    return null;
+  }
+
+  const lastSegment = url.pathname.slice(url.pathname.lastIndexOf('/') + 1);
+  if (FILE_SEGMENT.test(lastSegment)) {
+    return null;
+  }
+
+  const pathname = url.pathname.endsWith('/')
+    ? url.pathname
+    : `${url.pathname}/`;
+
+  return `${pathname}${url.search}${url.hash}`;
+}
+
+/**
+ * The parsed URL when `href` addresses this site, otherwise `undefined`.
+ *
+ * Only a rooted path gets this site as its base; anything else has to name the
+ * origin itself, and a bare fragment or a relative reference therefore fails to
+ * parse. The origin comparison still applies to rooted paths, because a leading
+ * `//` — or a `/\`, which the URL parser treats the same way — turns one into
+ * an authority and would otherwise route an off-site host as a local path.
+ */
+function internalUrl(href: string): URL | undefined {
+  // Chosen outside the `try`, which is there to catch an unparseable URL and
+  // must not also swallow a type error from a caller that skipped its guard.
+  const base = href.startsWith('/') ? SITE_URL : undefined;
+
+  let url: URL;
+  try {
+    url = new URL(href, base);
+  } catch {
+    return undefined;
+  }
+
+  return url.origin === SITE_ORIGIN ? url : undefined;
+}
+
+/**
+ * A Markdown link.
+ *
+ * Props pass through untouched in both branches: a Markdown title is the
+ * anchor's `title`, and neither branch may add a class — `p a`, `.prose a`, and
+ * `.about-content a` paint the accent underline that marks these as prose
+ * links, and per AGENTS.md only navigation-like links opt out of that.
+ */
+export function ProseLink({ href, ...rest }: ComponentPropsWithoutRef<'a'>) {
+  const route = markdownRouteHref(href);
+
+  if (route === null) {
+    return <a {...rest} href={href} />;
+  }
+
+  return <Link {...rest} href={route} />;
+}
+
+/** Spread into any `markdown-to-jsx` `overrides` object. */
+export const PROSE_LINK_OVERRIDES = {
+  a: { component: ProseLink },
+};


### PR DESCRIPTION
Blocker 2 from the integration-branch review: the comment written to replace the
false view-transition test was itself false.

## The claim, reproduced

`app/styles/__tests__/stylesheets.test.ts` said every internal link goes through
Next `<Link>`, so no same-origin cross-document navigation occurs. Built the
export and grepped it:

```
$ grep -o '<a href="/"[^>]*>Good design</a>' out/about/index.html
<a href="/">Good design</a>
```

`[Good design](/)` in `src/data/about.ts:39` renders through the default
`markdown-to-jsx` anchor, so `/about/` shipped a native same-origin link — a full
document load from a page that is otherwise entirely client-routed, and exactly
the navigation the deleted `@view-transition { navigation: auto }` rule could
have run for. The same is true of the writing surface: a draft post links to
`/writing/shipping-with-claude-code/` in prose.

## The fix

Took the first of the two offered paths — route internal Markdown links through
Next — rather than rewriting the comment to excuse the gap.

`src/lib/markdownLinks.tsx` classifies an href once and both prose surfaces share
it, so the two cannot drift:

| href | rendered as | why |
| --- | --- | --- |
| `/`, `/about`, `/about/`, `/writing/post#heading`, `/writing?tag=x` | `<Link>` | a route this router can address; normalised to the `trailingSlash: true` form (`/about` → `/about/`) |
| `https://mldangelo.com/about` | `<Link href="/about/">` | same origin, so the client navigation is available |
| `/feed.xml`, `/resume.json`, `/og.png`, `/images/....webp` | `<a>` | a file the host serves directly, not a route |
| `#some-history` | `<a>` | same-document scroll, not a navigation |
| `mailto:`, `tel:`, any other scheme | `<a>` | no origin to match |
| `https://example.com/...`, `//example.com/...`, `/\evil.com` | `<a>` | off-site — the last two parse to a foreign origin despite looking rooted |
| `sibling/`, `../other/`, `./same/` | `<a>` | the browser resolves a relative reference against the document URL and the router against the current route; left to the browser, and nothing in the content writes one |

Applied to `About/Sections` (all three Markdown blocks — intro, log sections,
plain sections) and to `Writing/PostContent`. Neither branch touches props or
adds a class, so a Markdown title still lands on `title`, an author-supplied
`target`/`rel` survives, and the accent underline from
`app/styles/base/links.css` still applies — these are prose links, which do not
opt out of it. Client boundaries are unchanged: both components were already
`'use client'`.

Then corrected the stale comment in `app/styles/__tests__/stylesheets.test.ts` to
state what is now true, including the residue (links to exported files stay
cross-document, and a feed or a PNG has no document on the other side that could
opt into a transition). The removed config-policy test is not re-added.

## Verification

- `npx vitest run`: 981 passed (964 on the base, plus 17 here). `npm run format`,
  `npx biome check .`, and `npx tsc --noEmit` are clean.
- Mutation-checked every guard in the new helper — deleting the file-segment
  check, the slash normalisation, the origin comparison, or the empty-href guard
  each turns the suite red.
- `next/link` renders a plain `<a>`, so the DOM cannot distinguish the branches;
  the unit tests assert the chosen component identity directly, and the two
  surface tests mark `<Link>` through a module mock.
- Built before and after: the rendered body markup of `/about/` and
  `/writing/shipping-with-claude-code/` is **byte-identical**, and the route
  sizes in the build output diff empty — nothing visual or size-related changed.
  What changed is the client module graph: the `/about/` and `/writing/[slug]`
  page chunks now depend on the `next/link` module (webpack module `8202`, the
  one carrying `prefetch`/`useLinkStatus`), which the baseline chunks did not.
- `npm run verify-export` (14 pages OK) and `npm run measure-export` (7 budgets
  within limits) both pass.
- Browser QA at desktop/390x844 was not possible here — the Chrome extension
  reported "not connected" and the CDP browser returned "Session closed" against
  a local static server. Since the exported markup is byte-identical, there is no
  visual delta to inspect; the runtime claim rests on the module-graph evidence
  and the component-identity tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
