### PR TITLE
fix(resume): derive the lead tier from the rendered order and match intern as a word

### DIFF
--- a/src/components/Resume/Experience.tsx
+++ b/src/components/Resume/Experience.tsx
@@ -31,8 +31,18 @@ function isoYear(date: string): number {
   return Number.parseInt(date.slice(0, 4), 10);
 }
 
+/**
+ * A student-era job title.
+ *
+ * Anchored on word boundaries because the bare substring `intern` also appears
+ * inside `internal`: `/intern/i` demoted "Internal Tools Engineer" and "Head of
+ * Internal Systems" to the student-era tier. The noun form is accepted too, so
+ * "Engineering Internship" places itself without another edit here.
+ */
+const INTERN_TITLE = /\bintern(ship)?\b/i;
+
 function isEarlyCareer(job: Position): boolean {
-  if (/intern/i.test(job.position)) {
+  if (INTERN_TITLE.test(job.position)) {
     return true;
   }
 
@@ -42,23 +52,38 @@ function isEarlyCareer(job: Position): boolean {
 /**
  * How much weight a role should carry on the spine.
  *
- * The lead is derived from the newest substantive start date, not array
- * position. This keeps reordering the source data from silently changing the
- * visual hierarchy while still letting ongoing side roles remain primary.
+ * The lead is the first substantive role in the order the spine actually
+ * renders — `sortPositions` owns that order, and this reads it rather than
+ * keeping a second, independent notion of "newest".
+ *
+ * It used to key on the newest `startDate`, which named the same role only
+ * while the spine was start-date ordered. Ordering then moved to the end date,
+ * and then gained a part-time exception, and nothing tied the two together. The
+ * two answers can disagree — an ongoing role outranks a stint that started
+ * later but has already closed — and when they do, the heaviest entry on the
+ * page sits somewhere in the middle of the list. Two roles beginning in the
+ * same month were both handed the lead, for the same reason: a date is not an
+ * identity.
+ *
+ * Deriving the lead from the rendered order rather than from "which role is
+ * current" is deliberate. The tier is a claim about the page — the entry at the
+ * top of the spine is the one carrying the weight — so it has to follow
+ * whatever ordering the spine uses. It also has to survive a current role that
+ * is early-career: an ongoing internship is genuinely the current job and must
+ * still never lead, so the lead is the first entry the `early` tier declines.
+ *
+ * `positions` may be handed over in any order; the sort happens here.
  */
 export function tierFor(job: Position, positions: Position[]): JobTier {
   if (isEarlyCareer(job)) return 'early';
 
-  const newestStartDate = positions
-    .filter((position) => !isEarlyCareer(position))
-    .map((position) => position.startDate)
-    .sort((a, b) => b.localeCompare(a))[0];
+  const lead = sortPositions(positions).find(
+    (position) => !isEarlyCareer(position),
+  );
 
-  if (job.startDate === newestStartDate) {
-    return 'lead';
-  }
-
-  return 'primary';
+  // Identity, not date equality: two entries that share a date are still two
+  // entries, and only the one rendered first leads.
+  return job === lead ? 'lead' : 'primary';
 }
 
 export default function Experience({
@@ -67,9 +92,10 @@ export default function Experience({
   // cannot quietly become one read per role.
   now = Date.now(),
 }: ExperienceProps) {
-  // `tierFor` was written not to depend on array position; sorting here is the
-  // other half of that decision. Without it the spine rendered in whatever
-  // order the data file happened to be in, which ran backwards in the middle.
+  // Without this the spine rendered in whatever order the data file happened
+  // to be in, which ran backwards in the middle. `tierFor` reads the same
+  // `sortPositions` order, so the entry that renders first is the entry that
+  // leads however this list arrives.
   const positions = sortPositions(data);
 
   return (

--- a/src/components/__tests__/Resume/Experience.test.tsx
+++ b/src/components/__tests__/Resume/Experience.test.tsx
@@ -110,6 +110,47 @@ describe('Experience', () => {
     expect(first?.querySelector('.job-company')?.textContent).toBe('Newest Co');
   });
 
+  /**
+   * The lead tier and the render order are two readings of the same list, and
+   * they used to be derived separately — the order from `timelineKey`, the lead
+   * from the newest `startDate`. When those disagree the heaviest entry on the
+   * page is not the one at the top of it. Here the brief stint began later but
+   * has closed, so the ongoing role renders first and has to carry the weight.
+   */
+  it('puts the lead tier on the role it renders first', () => {
+    render(
+      <Experience
+        data={[
+          {
+            ...mockJobs[0],
+            name: 'Long Ongoing Co',
+            startDate: '2015-01-01',
+            endDate: undefined,
+          },
+          {
+            ...mockJobs[1],
+            name: 'Brief Recent Co',
+            startDate: '2024-01-01',
+            endDate: '2024-06-01',
+          },
+        ]}
+        now={new Date('2026-07-28T12:00:00Z').getTime()}
+      />,
+    );
+
+    const tiers = Array.from(document.querySelectorAll('.jobs-container')).map(
+      (node) => ({
+        company: node.querySelector('.job-company')?.textContent,
+        lead: node.classList.contains('jobs-container--lead'),
+      }),
+    );
+
+    expect(tiers).toEqual([
+      { company: 'Long Ongoing Co', lead: true },
+      { company: 'Brief Recent Co', lead: false },
+    ]);
+  });
+
   it('measures every ongoing role against a single shared instant', () => {
     const now = new Date('2026-07-28T12:00:00Z').getTime();
 

--- a/src/components/__tests__/Resume/tierFor.test.ts
+++ b/src/components/__tests__/Resume/tierFor.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { Position } from '@/data/resume/work';
+import { sortPositions } from '@/lib/career';
 import { tierFor } from '../../Resume/Experience';
 
 function position(overrides: Partial<Position> = {}): Position {
@@ -15,7 +16,7 @@ function position(overrides: Partial<Position> = {}): Position {
 }
 
 describe('tierFor', () => {
-  it('leads with the newest substantive role regardless of array position', () => {
+  it('leads with the top substantive role regardless of array position', () => {
     const older = position({
       name: 'Older Corp',
       startDate: '2020-01-01',
@@ -29,6 +30,100 @@ describe('tierFor', () => {
 
     expect(tierFor(newest, positions)).toBe('lead');
     expect(tierFor(older, positions)).toBe('primary');
+  });
+
+  /**
+   * The lead has to be the entry the spine renders first, and the spine is
+   * ordered by `timelineKey` — recency of *involvement* — not by start date.
+   * The two disagree here: the brief stint began later, but it has closed and
+   * the long role has not, so the long role renders above it. Keying the lead
+   * on the newest start date put the heaviest entry second.
+   */
+  it('leads with the first rendered role when that is not the newest start', () => {
+    const ongoing = position({
+      name: 'Long Ongoing Co',
+      position: 'Co-founder & CTO',
+      startDate: '2015-01-01',
+      endDate: undefined,
+    });
+    const laterButClosed = position({
+      name: 'Brief Recent Co',
+      startDate: '2024-01-01',
+      endDate: '2024-06-01',
+    });
+    const positions = [ongoing, laterButClosed];
+
+    expect(sortPositions(positions)[0]).toBe(ongoing);
+    expect(tierFor(ongoing, positions)).toBe('lead');
+    expect(tierFor(laterButClosed, positions)).toBe('primary');
+  });
+
+  /**
+   * `timelineKey` places an open-ended *part-time* role by when it began, so a
+   * fund that never formally ends does not park itself above the full-time
+   * record. The tier has to honour the same exception: the fund started most
+   * recently, but it renders last.
+   */
+  it('does not lead with an open-ended part-time role that renders below', () => {
+    const fund = position({
+      name: 'Side Fund',
+      position: 'Co-founder',
+      startDate: '2026-06-01',
+      endDate: undefined,
+      commitment: 'part-time',
+    });
+    const dayJob = position({
+      name: 'Current Job',
+      startDate: '2018-01-01',
+      endDate: undefined,
+    });
+    const positions = [fund, dayJob];
+
+    expect(sortPositions(positions)[0]).toBe(dayJob);
+    expect(tierFor(dayJob, positions)).toBe('lead');
+    expect(tierFor(fund, positions)).toBe('primary');
+  });
+
+  it('leads exactly one role when two share the newest date', () => {
+    const first = position({
+      name: 'First Co',
+      startDate: '2026-01-01',
+      endDate: undefined,
+    });
+    const second = position({
+      name: 'Second Co',
+      startDate: '2026-01-01',
+      endDate: undefined,
+    });
+    const positions = [first, second];
+
+    const tiers = positions.map((entry) => tierFor(entry, positions));
+
+    expect(tiers.filter((tier) => tier === 'lead')).toHaveLength(1);
+    expect(tierFor(sortPositions(positions)[0], positions)).toBe('lead');
+  });
+
+  /**
+   * The lead is the first entry the `early` tier declines, not simply the first
+   * entry: an ongoing internship is the current role and still must not lead.
+   */
+  it('skips past an early-career role sitting at the top of the spine', () => {
+    const internship = position({
+      name: 'Rocket Co',
+      position: 'Avionics Intern',
+      startDate: '2026-01-01',
+      endDate: undefined,
+    });
+    const realJob = position({
+      name: 'Day Job',
+      startDate: '2020-01-01',
+      endDate: '2025-01-01',
+    });
+    const positions = [internship, realJob];
+
+    expect(sortPositions(positions)[0]).toBe(internship);
+    expect(tierFor(internship, positions)).toBe('early');
+    expect(tierFor(realJob, positions)).toBe('lead');
   });
 
   it('never promotes an internship with the newest date to lead', () => {
@@ -67,6 +162,27 @@ describe('tierFor', () => {
     );
   });
 
+  it('reads the intern rule as a word, not a substring', () => {
+    // `/intern/i` matches inside `internal`, which demoted a senior role to the
+    // student-era tier.
+    const internalTools = position({
+      position: 'Internal Tools Engineer',
+      startDate: '2024-01-01',
+      endDate: undefined,
+    });
+
+    expect(tierFor(internalTools, [internalTools])).toBe('lead');
+    expect(
+      tierFor(position({ position: 'Head of Internal Systems' }), []),
+    ).toBe('primary');
+  });
+
+  it('still demotes the noun form of the title', () => {
+    expect(tierFor(position({ position: 'Engineering Internship' }), [])).toBe(
+      'early',
+    );
+  });
+
   it('steps student-era roles down even when not titled intern', () => {
     expect(
       tierFor(
@@ -87,25 +203,26 @@ describe('tierFor', () => {
     expect(tierFor(role, [newer, role])).toBe('primary');
   });
 
-  it('treats an ongoing role as primary when it is not the newest', () => {
-    expect(
-      tierFor(
-        position({
-          name: 'Side Fund',
-          position: 'Co-founder',
-          startDate: '2017-01-01',
-          endDate: undefined,
-        }),
-        [
-          position({ name: 'Current Job', startDate: '2026-01-01' }),
-          position({
-            name: 'Side Fund',
-            position: 'Co-founder',
-            startDate: '2017-01-01',
-            endDate: undefined,
-          }),
-        ],
-      ),
-    ).toBe('primary');
+  /**
+   * Two roles still running tie on `timelineKey`, and the tie breaks on the
+   * newer start — so the older of the two is primary even though it has not
+   * ended either.
+   */
+  it('treats an ongoing role as primary when another began more recently', () => {
+    const older = position({
+      name: 'Long Haul Co',
+      position: 'Co-founder',
+      startDate: '2017-01-01',
+      endDate: undefined,
+    });
+    const newer = position({
+      name: 'Current Job',
+      startDate: '2026-01-01',
+      endDate: undefined,
+    });
+    const positions = [older, newer];
+
+    expect(tierFor(older, positions)).toBe('primary');
+    expect(tierFor(newer, positions)).toBe('lead');
   });
 });


### PR DESCRIPTION
Two confirmed findings in `src/components/Resume/Experience.tsx`. Both are latent — the built export is byte-for-byte the same tiers — but both are the kind that go live the next time the résumé data changes.

## 1. The lead tier was derived from a second, independent notion of "newest"

`tierFor` keyed the lead on the newest substantive `startDate`. The spine renders in `sortPositions` order, keyed on `timelineKey`. Those name the same entry only while the spine is start-date ordered — which stopped being true twice on this branch, first when ordering moved to the end date (`267d356`) and again when it gained the part-time exception (`abb673f`). Neither touched `tierFor`.

When the two disagree, the heaviest entry on the page is not the one at the top of it. Verified correct for the current data: OpenAI is both the newest start and the first rendered role.

The lead is now the first entry in `sortPositions(positions)` that the `early` tier declines.

**Why the rendered order and not `currentPosition`.** The brief asked for a deliberate choice between them; they can differ. The tier is a claim about the page — the entry at the top of the spine is the one carrying the weight — so it has to follow whatever ordering the spine actually uses, and it must keep doing so if that ordering changes a third time. It also has to survive a lead candidate that is early-career: an ongoing internship *is* the current role and must still never lead (a pinned test), which "the current role" alone cannot express. `currentPosition` on `fix/current-role-single-source` answers a different question — the site-wide "where does he work now" for JSON-LD and the footer — and correctly excludes part-time; this needs "what sits at the top of this list". `career.ts` is untouched here, so the two land in the integration branch without overlapping.

Comparing identity rather than dates also closes a second latent case: two roles beginning in the same month were **both** handed the lead.

## 2. `intern` was matched as a substring

`/intern/i` matches inside `internal`, so "Internal Tools Engineer" or "Head of Internal Systems" would render at the student-era tier. Pre-existing — unchanged from `main` — and no current title trips it. Now `/\bintern(ship)?\b/i`, which reads it as a word and still catches the noun form so a future "Engineering Internship" places itself.

## Tests

Seven added, including the constructed divergence the brief asked for — a brief stint that began later but has already closed, sitting under an ongoing role — plus the open-ended part-time fund, and a DOM-level assertion in `Experience.test.tsx` that the `--lead` class lands on the first rendered article.

Mutation-verified in four directions:

| mutation | tests killed |
| --- | --- |
| restore `newestStartDate` | 4 |
| restore `/intern/i` | 1 |
| `.find(not early)` → `[0]` | 1 |
| drop `(ship)?` | 1 |

## Verification

`npm run format`, `npx biome check .` (224 files, clean), `npx tsc --noEmit` clean, `npx vitest run` 971 passed / 83 files — up from a 964 baseline, nothing changed status. `npm run build` succeeds; `out/resume/index.html` renders the lead on OpenAI, exactly one lead, and the same four early-career entries as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)