### PR TITLE
fix(scripts): flag a draft post's article images, not just files named after its slug

### DIFF
--- a/scripts/__tests__/verify-export.test.ts
+++ b/scripts/__tests__/verify-export.test.ts
@@ -10,6 +10,12 @@ import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
+import {
+  assetRoute,
+  declaredAssetRoutes,
+  draftOnlyAssetRoutes,
+} from '../lib/markdown.mjs';
+
 const verifier = resolve(process.cwd(), 'scripts/verify-export.mjs');
 const fixtureRoots: string[] = [];
 
@@ -163,6 +169,15 @@ function mutate(
 ) {
   const file = join(root, path);
   writeFileSync(file, transform(readFileSync(file, 'utf8')));
+}
+
+/** Gives the fixture's draft a body, keeping its `draft: true` frontmatter. */
+function draftWithBody(root: string, body: string) {
+  write(
+    root,
+    'content/writing/secret-draft.md',
+    `---\ntitle: Secret draft\ndraft: true # keep private\n---\n\n${body}\n`,
+  );
 }
 
 function runVerifier(root: string) {
@@ -458,6 +473,159 @@ describe('verify-export', () => {
     );
   });
 
+  /**
+   * The hole the slug scan cannot cover. A post's screenshots are filed wherever
+   * the author filed them, and this repository's draft keeps three in
+   * `public/images/writing/codex-desktop-app-post/` — a directory name that is
+   * not the slug and is not derived from it, so no filename rule could see it.
+   * The post's own Markdown can.
+   */
+  it('reports a draft image filed in an arbitrarily named directory', () => {
+    const root = createFixture();
+    draftWithBody(
+      root,
+      '![A screenshot](/images/writing/codex-desktop-app-post/overview.webp)',
+    );
+    write(root, 'out/images/writing/codex-desktop-app-post/overview.webp');
+
+    const result = runVerifier(root);
+    expect(result.status).toBe(0);
+    expect(result.output).toContain(
+      'images/writing/codex-desktop-app-post/overview.webp\n    draft post "secret-draft" references this file',
+    );
+    expect(result.output).toContain(
+      'publicly fetchable at https://example.com/images/writing/codex-desktop-app-post/overview.webp',
+    );
+  });
+
+  /**
+   * A warning that only appears above a line reading `3 pages OK` is a warning
+   * nobody reads. The count rides on the success line too.
+   */
+  it('carries the warning count on the success line', () => {
+    const root = createFixture();
+    draftWithBody(root, '![Shot](/images/writing/loose/shot.webp)');
+    write(root, 'out/images/writing/loose/shot.webp');
+
+    const result = runVerifier(root);
+    expect(result.status).toBe(0);
+    expect(result.output).toContain(
+      'verify-export: 1 warning(s), not blocking the build',
+    );
+    expect(result.output).toContain('3 pages OK, 1 warning(s)');
+  });
+
+  it('reports a draft image declared only in frontmatter', () => {
+    const root = createFixture();
+    write(
+      root,
+      'content/writing/secret-draft.md',
+      '---\ntitle: Secret draft\ndraft: true\nimage: /images/elsewhere/hero.png\nimageAlt: Hero\n---\n',
+    );
+    write(root, 'out/images/elsewhere/hero.png');
+
+    const result = runVerifier(root);
+    expect(result.status).toBe(0);
+    expect(result.output).toContain(
+      'images/elsewhere/hero.png\n    draft post "secret-draft" references this file',
+    );
+  });
+
+  it('accepts article images belonging to a published post', () => {
+    const root = createFixture();
+    write(
+      root,
+      'content/writing/published.md',
+      '---\ntitle: Published\nimage: /images/writing/published/hero.png\nimageAlt: Hero\n---\n\n![Chart](/images/writing/published/chart.png)\n',
+    );
+    write(root, 'out/images/writing/published/hero.png');
+    write(root, 'out/images/writing/published/chart.png');
+
+    const result = runVerifier(root);
+    expect(result.status).toBe(0);
+    expect(result.output).not.toContain('warning');
+    expect(result.output).toContain('3 pages OK (');
+  });
+
+  /**
+   * An illustration used by a published post and quoted by a draft still has to
+   * ship. Reporting it would be the same false positive the slug scan was
+   * narrowed to avoid: a committed file nothing derived from an unpublished
+   * post, named as a draft leak.
+   */
+  it('accepts an image a draft shares with a published post', () => {
+    const root = createFixture();
+    draftWithBody(root, '![Shared](/images/writing/shared/diagram.png)');
+    write(
+      root,
+      'content/writing/published.md',
+      '---\ntitle: Published\n---\n\n![Shared](/images/writing/shared/diagram.png)\n',
+    );
+    write(root, 'out/images/writing/shared/diagram.png');
+
+    const result = runVerifier(root);
+    expect(result.status).toBe(0);
+    expect(result.output).not.toContain('warning');
+  });
+
+  /**
+   * The reference scan matches whole paths, and must not grow into a directory
+   * or prefix rule. `-notes.png` is a sibling nothing declared; widening the
+   * match to catch it would reintroduce the false-positive class the slug scan
+   * was already narrowed to fix.
+   */
+  it('accepts a neighbouring file whose name only resembles a draft image', () => {
+    const root = createFixture();
+    draftWithBody(root, '![Shot](/images/writing/loose/shot.webp)');
+    write(root, 'out/images/writing/loose/shot-notes.png');
+    write(root, 'out/images/writing/loose-extra.png');
+
+    const result = runVerifier(root);
+    expect(result.status).toBe(0);
+    expect(result.output).not.toContain('warning');
+  });
+
+  /**
+   * A remote image names a host, so its path is not a file here. Resolving one
+   * as a route would report `out/images/photo.png` — a committed asset the draft
+   * never mentioned.
+   */
+  it('ignores an off-site image reference in a draft', () => {
+    const root = createFixture();
+    draftWithBody(root, '![Remote](https://cdn.example/images/photo.png)');
+
+    const result = runVerifier(root);
+    expect(result.status).toBe(0);
+    expect(result.output).not.toContain('warning');
+  });
+
+  it('stays silent about a draft image that is not in the export', () => {
+    const root = createFixture();
+    draftWithBody(root, '![Missing](/images/writing/loose/absent.webp)');
+
+    const result = runVerifier(root);
+    expect(result.status).toBe(0);
+    expect(result.output).not.toContain('warning');
+  });
+
+  /**
+   * One file, one report. A draft image that also sits under a slug-named
+   * directory is caught by both checks, and the fatal one is the one that
+   * should speak.
+   */
+  it('reports a slug-named draft image once, as a failure', () => {
+    const root = createFixture();
+    draftWithBody(root, '![Shot](/images/writing/secret-draft/shot.webp)');
+    write(root, 'out/images/writing/secret-draft/shot.webp');
+
+    const result = runVerifier(root);
+    expect(result.status).toBe(1);
+    expect(result.output).toContain(
+      'exports an asset named after a draft post: /images/writing/secret-draft/shot.webp',
+    );
+    expect(result.output).not.toContain('warning');
+  });
+
   it('rejects an export with no machine-readable resume', () => {
     const root = createFixture();
     rmSync(join(root, 'out/resume.json'));
@@ -529,5 +697,159 @@ describe('verify-export', () => {
     expect(result.output).toContain(
       'sitemap.xml\n    omits indexable route: /about/',
     );
+  });
+});
+
+/**
+ * `scripts/lib/` is imported directly rather than reached only through the gate,
+ * for the reason `site.mjs` and `html.mjs` are: a fixture exercises one shape of
+ * input, and the awkward edges here — a title after the destination, an
+ * angle-bracketed path, a linked image, a scheme that is not http — never occur
+ * in this repository's own posts, so nothing would fail if they stopped working.
+ */
+describe('assetRoute', () => {
+  it.each([
+    ['a root-relative path', '/images/writing/post/shot.webp'],
+    ['surrounding whitespace', '  /images/writing/post/shot.webp  '],
+    ['an angle-bracketed path', '</images/writing/post/shot.webp>'],
+    ['a query string', '/images/writing/post/shot.webp?v=2'],
+    ['a fragment', '/images/writing/post/shot.webp#top'],
+  ])('resolves %s', (_, reference) => {
+    expect(assetRoute(reference)).toBe('/images/writing/post/shot.webp');
+  });
+
+  it('keeps a percent-encoded path encoded for the export lookup', () => {
+    // `exportFileFor` decodes; decoding twice would resolve `%2F` as a
+    // separator and reach outside the directory the author named.
+    expect(assetRoute('/images/writing/a%20b.png')).toBe(
+      '/images/writing/a%20b.png',
+    );
+  });
+
+  it.each([
+    ['an https URL', 'https://cdn.example/images/photo.png'],
+    ['an http URL', 'http://cdn.example/images/photo.png'],
+    ['a data URI', 'data:image/png;base64,AAAA'],
+    ['a protocol-relative URL', '//cdn.example/images/photo.png'],
+    ['a document-relative path', 'images/photo.png'],
+    ['a parent-relative path', '../images/photo.png'],
+    ['the site root', '/'],
+    ['an empty reference', '   '],
+    ['a non-string', undefined],
+  ])('declines %s', (_, reference) => {
+    expect(assetRoute(reference)).toBeUndefined();
+  });
+});
+
+describe('declaredAssetRoutes', () => {
+  it('reads the frontmatter image', () => {
+    expect([
+      ...declaredAssetRoutes({
+        data: { image: '/images/writing/post/hero.png' },
+        content: '',
+      }),
+    ]).toEqual(['/images/writing/post/hero.png']);
+  });
+
+  it.each([
+    ['a plain image', '![Alt](/images/a.png)'],
+    ['an image with a caption title', '![Alt](/images/a.png "A caption")'],
+    ['an angle-bracketed destination', '![Alt](</images/a.png>)'],
+    ['a linked image', '[![Alt](/images/a.png)](https://example.com/)'],
+    ['inline HTML', '<img src="/images/a.png" alt="Alt">'],
+    ['padding inside the parentheses', '![Alt]( /images/a.png )'],
+  ])('reads %s', (_, body) => {
+    expect([...declaredAssetRoutes({ data: {}, content: body })]).toEqual([
+      '/images/a.png',
+    ]);
+  });
+
+  it('reads every image in a document once', () => {
+    const content = [
+      '![One](/images/a.png)',
+      'Prose about it.',
+      '![Two](/images/b.png)',
+      '![One again](/images/a.png)',
+    ].join('\n\n');
+
+    expect([...declaredAssetRoutes({ data: {}, content })]).toEqual([
+      '/images/a.png',
+      '/images/b.png',
+    ]);
+  });
+
+  /**
+   * Unlike the word and reference counts in `og-inputs.mjs`, which measure what
+   * a reader sees. This asks which files belong to the post, and a path an
+   * author wrote inside a fence is still that answer.
+   */
+  it('reads a path inside fenced code', () => {
+    const content = '```md\n![Alt](/images/a.png)\n```\n';
+
+    expect([...declaredAssetRoutes({ data: {}, content })]).toEqual([
+      '/images/a.png',
+    ]);
+  });
+
+  it('skips remote and relative references', () => {
+    const content = [
+      '![Remote](https://cdn.example/images/photo.png)',
+      '![Relative](images/photo.png)',
+      '![Local](/images/a.png)',
+    ].join('\n\n');
+
+    expect([...declaredAssetRoutes({ data: {}, content })]).toEqual([
+      '/images/a.png',
+    ]);
+  });
+
+  it('returns nothing for a post with no images and no arguments', () => {
+    expect([
+      ...declaredAssetRoutes({ data: {}, content: 'Just prose.' }),
+    ]).toEqual([]);
+    expect([...declaredAssetRoutes()]).toEqual([]);
+  });
+});
+
+describe('draftOnlyAssetRoutes', () => {
+  const post = (slug: string, isDraft: boolean, routes: string[]) => ({
+    slug,
+    isDraft,
+    assets: new Set(routes),
+  });
+
+  it('names the draft that declared each asset', () => {
+    const owners = draftOnlyAssetRoutes([
+      post('secret', true, ['/images/a.png', '/images/b.png']),
+    ]);
+
+    expect([...owners]).toEqual([
+      ['/images/a.png', 'secret'],
+      ['/images/b.png', 'secret'],
+    ]);
+  });
+
+  it('subtracts assets a published post also declares', () => {
+    const owners = draftOnlyAssetRoutes([
+      post('secret', true, ['/images/shared.png', '/images/only-draft.png']),
+      post('shipped', false, ['/images/shared.png']),
+    ]);
+
+    expect([...owners.keys()]).toEqual(['/images/only-draft.png']);
+  });
+
+  it('attributes an asset two drafts share to the first of them', () => {
+    const owners = draftOnlyAssetRoutes([
+      post('first', true, ['/images/a.png']),
+      post('second', true, ['/images/a.png']),
+    ]);
+
+    expect(owners.get('/images/a.png')).toBe('first');
+  });
+
+  it('returns nothing when every post is published', () => {
+    expect(
+      draftOnlyAssetRoutes([post('shipped', false, ['/images/a.png'])]).size,
+    ).toBe(0);
   });
 });

--- a/scripts/lib/markdown.mjs
+++ b/scripts/lib/markdown.mjs
@@ -1,0 +1,140 @@
+/**
+ * Reading the assets a post declares out of its own Markdown source.
+ *
+ * `verify-export.mjs` gates draft leaks two ways, and this is the half that does
+ * not depend on naming. A slug rule can only see what the build *derives* from a
+ * post — the share card is `og/writing/<slug>.png` by construction, and a leaked
+ * route's RSC payload sits inside `writing/<slug>/` — but an author's
+ * screenshots are filed wherever the author filed them. The draft in this
+ * repository keeps three in `public/images/writing/codex-desktop-app-post/`, a
+ * directory name that is not the slug and is not derived from it, so no filename
+ * rule could ever have caught them.
+ *
+ * What can see them is the post itself. A post declares its images: the `image`
+ * frontmatter field, and every image reference in the body. Reading that
+ * declaration binds an exported file to the post it belongs to whatever the
+ * directory is called, which is why the two checks are complementary rather than
+ * alternatives — keep both.
+ *
+ * These are regexes rather than a Markdown parser for the same reason
+ * `html.mjs` scrapes markup as text: this runs after the build, and the site's
+ * own renderer (`markdown-to-jsx`) is a browser-oriented dependency that a gate
+ * has no business booting. The failure mode is chosen to match: a construct
+ * these patterns cannot read is *missed*, never mis-attributed, so the gate
+ * under-reports rather than failing a build over a file it invented.
+ */
+import { attribute, tags } from './html.mjs';
+
+/**
+ * `![alt](destination "title")`, capturing the destination.
+ *
+ * The destination stops at whitespace, so a title is left behind, or is the
+ * angle-bracketed form, which is how CommonMark spells a path containing
+ * spaces. Alt text is `[^\]]*`: a nested bracket inside alt ends the match
+ * early and the reference is missed, which is the safe direction. A linked
+ * image (`[![alt](src)](href)`) still matches, because the inner image is a
+ * complete reference on its own — that form is in use here, so it is not
+ * hypothetical.
+ */
+const MARKDOWN_IMAGE = /!\[[^\]]*\]\(\s*(<[^<>]*>|[^\s)]*)/g;
+
+/**
+ * A URL scheme or the protocol-relative form. Both name a host, so neither can
+ * be a file in this export.
+ */
+const OFF_SITE = /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i;
+
+/**
+ * A reference resolved to the route its file occupies in the export, or
+ * `undefined` when it is not a local file at all.
+ *
+ * Root-relative only. That is the form `validatePostFrontmatter` in
+ * `src/lib/posts.ts` already requires of `image`, and the only form that
+ * resolves to the same file from every route once `trailingSlash: true` has
+ * given each post its own directory. A document-relative reference is therefore
+ * not silently reinterpreted here; it is declined, because guessing the base it
+ * was written against is how a gate ends up naming the wrong file.
+ *
+ * The result is a route — `out/` is the site root on disk, and a
+ * repository-site base path is not — so a caller comparing it against the
+ * export has to put the base path back with `publicPathForRoute` first.
+ */
+export function assetRoute(reference) {
+  if (typeof reference !== 'string') return undefined;
+
+  let value = reference.trim();
+  if (value.startsWith('<') && value.endsWith('>')) {
+    value = value.slice(1, -1).trim();
+  }
+
+  if (!value || OFF_SITE.test(value) || !value.startsWith('/')) {
+    return undefined;
+  }
+
+  // A query or fragment on an image is decoration; the file is the same file.
+  const route = value.replace(/[?#].*$/, '');
+  return route === '/' ? undefined : route;
+}
+
+/**
+ * Every local asset route one post declares.
+ *
+ * Fenced code is deliberately *not* stripped, unlike the word and reference
+ * counts in `og-inputs.mjs`. Those measure what a reader sees; this asks which
+ * files belong to this post, and a path an author wrote inside a fence is still
+ * that answer. The cost of including it — a draft quoting a path a published
+ * post also uses — is paid by the caller, which subtracts what published posts
+ * declare before reporting anything.
+ *
+ * Inline `<img>` is read as well as Markdown image syntax, because
+ * `markdown-to-jsx` renders raw HTML and so a post may legitimately be written
+ * that way.
+ */
+export function declaredAssetRoutes({ data, content } = {}) {
+  const body = typeof content === 'string' ? content : '';
+  const references = [
+    data?.image,
+    ...[...body.matchAll(MARKDOWN_IMAGE)].map((match) => match[1]),
+    ...tags(body, 'img').map((tag) => attribute(tag, 'src')),
+  ];
+
+  const routes = new Set();
+  for (const reference of references) {
+    const route = assetRoute(reference);
+    if (route !== undefined) routes.add(route);
+  }
+  return routes;
+}
+
+/**
+ * Assets declared by a draft and by no published post, mapped to the draft that
+ * declared each.
+ *
+ * The subtraction is the point. An illustration shared between a draft and a
+ * published post has to ship, and reporting it would be a false positive of
+ * exactly the kind the slug scan was narrowed to avoid — a committed file that
+ * nothing derived from an unpublished post, named as a draft leak. Where two
+ * drafts declare the same file the first by scan order is named; the file is
+ * one file either way and the message only needs to point somewhere real.
+ *
+ * `posts` entries are `{ slug, isDraft, assets }`, where `assets` is the set
+ * from `declaredAssetRoutes`.
+ */
+export function draftOnlyAssetRoutes(posts) {
+  const published = new Set();
+  for (const post of posts) {
+    if (!post.isDraft) {
+      for (const route of post.assets) published.add(route);
+    }
+  }
+
+  const owners = new Map();
+  for (const post of posts) {
+    if (!post.isDraft) continue;
+    for (const route of post.assets) {
+      if (published.has(route) || owners.has(route)) continue;
+      owners.set(route, post.slug);
+    }
+  }
+  return owners;
+}

--- a/scripts/verify-export.mjs
+++ b/scripts/verify-export.mjs
@@ -20,6 +20,7 @@ import {
   metaValues,
   tags,
 } from './lib/html.mjs';
+import { declaredAssetRoutes, draftOnlyAssetRoutes } from './lib/markdown.mjs';
 import { exportLayout, readSiteConfig, toUrlPath } from './lib/site.mjs';
 import { isDraftFrontmatter, POST_CARD_DIRECTORY } from './og-inputs.mjs';
 
@@ -29,6 +30,17 @@ const CONTENT = resolve(ROOT, 'content/writing');
 
 const failures = [];
 const fail = (page, message) => failures.push({ page, message });
+
+/**
+ * Reported but not fatal.
+ *
+ * Everything else here is a defect in something the build produced, and the
+ * build is the thing that can be fixed. A warning is for a true finding whose
+ * remedy is a decision only the author can make — see
+ * `DRAFT_REFERENCED_ASSETS_FAIL`.
+ */
+const warnings = [];
+const warn = (page, message) => warnings.push({ page, message });
 
 function walk(dir, match) {
   const found = [];
@@ -65,15 +77,25 @@ if (pages.length === 0) {
   process.exit(1);
 }
 
-const draftSlugs = walk(CONTENT, (name) => name.endsWith('.md'))
+const posts = walk(CONTENT, (name) => name.endsWith('.md')).map((path) => {
   // Use the same YAML parser as the application. A line regex misses valid
   // forms such as `draft: true # keep private`, weakening the fault-injection
   // gate precisely when the route layer regresses. `isDraftFrontmatter` is the
   // share-card scripts' predicate, imported rather than repeated: a gate that
   // disagreed with the generator about what a draft is would wave through the
   // exact artifact the generator should never have produced.
-  .filter((path) => isDraftFrontmatter(matter(readFileSync(path, 'utf8')).data))
-  .map((path) => basename(path, '.md'));
+  const { data, content } = matter(readFileSync(path, 'utf8'));
+
+  return {
+    slug: basename(path, '.md'),
+    isDraft: isDraftFrontmatter(data),
+    assets: declaredAssetRoutes({ data, content }),
+  };
+});
+
+const draftSlugs = posts
+  .filter((post) => post.isDraft)
+  .map((post) => post.slug);
 
 function isDraftPath(pathname) {
   const route = routeForPublicPath(pathname) ?? pathname;
@@ -84,21 +106,24 @@ function isDraftPath(pathname) {
 }
 
 /**
- * Where in the export a file belonging to one post can appear.
+ * Where in the export a file *named after* a post can appear.
  *
  * `POST_CARD_DIRECTORY` is the generated share cards, taken from the generator's
  * own constant so moving them cannot silently un-scope this gate. `/writing` is
  * the posts' own route tree, which carries more than HTML: Next writes an RSC
  * prefetch payload beside every prerendered route, so a leaked draft route also
  * ships an `index.txt` that no metadata check reads. `/images/writing` is where
- * article images live, one directory per post.
+ * article images live.
  *
- * A new per-post asset directory has to be registered here, or it ships
- * unwatched — that is the cost of scoping, and it is the smaller cost. The scan
- * used to match any path segment anywhere in `out/`, which meant a draft slug
- * colliding with an unrelated committed file (`notes.md` against
- * `public/images/notes.png`) failed the whole build with a draft-leak message
- * pointing at a file nothing generated.
+ * Scoping is what keeps a slug rule honest: the scan used to match any path
+ * segment anywhere in `out/`, which meant a draft slug colliding with an
+ * unrelated committed file (`notes.md` against `public/images/notes.png`) failed
+ * the whole build with a draft-leak message pointing at a file nothing
+ * generated. The cost is that a name this list does not cover is invisible here
+ * — which is not the same as unwatched, because the reference scan below reads
+ * the post's own declaration and does not care about names at all. Register a
+ * new directory that holds *generated* per-post files anyway; the Markdown
+ * cannot reference what the build invents.
  */
 const POST_ASSET_ROOTS = [POST_CARD_DIRECTORY, '/writing', '/images/writing'];
 
@@ -122,13 +147,14 @@ function isDraftAsset(route) {
 }
 
 /**
- * Nothing generated from a draft may reach the export, not only routes.
+ * Nothing belonging to a draft may reach the export, not only routes.
  *
  * The route and metadata checks below see HTML and XML. `public/` is copied
- * into the export verbatim, so anything generated from `content/writing/` — a
- * per-post share card, say — reaches the site as a plain file that no metadata
- * gate looks at, carrying an unpublished title in its name and its pixels.
- * HTML is skipped here only because `isDraftPath` already covers every route.
+ * into the export verbatim, so anything belonging to an unpublished post — a
+ * per-post share card, an author's screenshots — reaches the site as a plain
+ * file that no metadata gate looks at, carrying unpublished work in its name
+ * and its pixels. HTML is skipped here only because `isDraftPath` already
+ * covers every route.
  */
 if (draftSlugs.length > 0) {
   for (const file of walk(OUT, (name) => !name.endsWith('.html'))) {
@@ -140,6 +166,45 @@ if (draftSlugs.length > 0) {
       fail(path, `exports an asset named after a draft post: /${path}`);
     }
   }
+}
+
+/**
+ * Whether a file a draft's Markdown points at should block the build.
+ *
+ * `false`, deliberately, and this is the one line to flip to change that.
+ *
+ * The two draft-asset checks find different things. A file named after a draft
+ * is one the build produced from an unpublished post, and the build is what gets
+ * fixed — failing is right, and no author is inconvenienced by it. A file a
+ * draft *references* is the author's own: committing the screenshots alongside
+ * the draft that will use them is the normal way to write a post here, and the
+ * remedy is a decision about the author's own working copy — move them out of
+ * `public/` until the post ships, or accept the exposure knowingly. Failing
+ * would make that decision by stopping every deploy from `main` until someone
+ * happened to look, and the exposure is not undone by a red build; it is only
+ * reported. So it is reported, loudly, by name, with the URL.
+ */
+const DRAFT_REFERENCED_ASSETS_FAIL = false;
+
+/**
+ * Files a draft declares as its own, wherever they were filed.
+ *
+ * This is the half of the draft-asset gate that does not go through names. The
+ * live example is `public/images/writing/codex-desktop-app-post/`, three
+ * screenshots for a `draft: true` post in a directory whose name appears in no
+ * slug — publicly fetchable, and invisible to every other check here.
+ */
+for (const [route, slug] of draftOnlyAssetRoutes(posts)) {
+  // Already fatal above, and one file deserves one report.
+  if (isDraftAsset(route)) continue;
+  if (!exportedFileExists(publicPathForRoute(route))) continue;
+
+  (DRAFT_REFERENCED_ASSETS_FAIL ? fail : warn)(
+    route.replace(/^\//, ''),
+    `draft post "${slug}" references this file, so it is publicly fetchable at ` +
+      `${siteUrlForRoute(route)}. Move it out of public/ until the post ships, ` +
+      'or leave it knowing it is readable.',
+  );
 }
 
 const records = pages.map((file) => {
@@ -665,6 +730,15 @@ if (!existsSync(resumeJsonPath)) {
   }
 }
 
+if (warnings.length > 0) {
+  console.warn(
+    `\nverify-export: ${warnings.length} warning(s), not blocking the build\n`,
+  );
+  for (const { page, message } of warnings) {
+    console.warn(`  ${page}\n    ${message}`);
+  }
+}
+
 if (failures.length > 0) {
   console.error(`\nverify-export: ${failures.length} problem(s)\n`);
   for (const { page, message } of failures) {
@@ -673,7 +747,10 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
+// The warning count rides on the success line as well as being printed above,
+// so a passing run never reads as clean when it is not.
 console.log(
-  `verify-export: ${pages.length} pages OK ` +
-    '(draft routes and assets, robots, ids/fragments, canonicals, complete share metadata, local images, internal links, sitemap/RSS, resume.json)',
+  `verify-export: ${pages.length} pages OK` +
+    (warnings.length > 0 ? `, ${warnings.length} warning(s)` : '') +
+    ' (draft routes and assets, robots, ids/fragments, canonicals, complete share metadata, local images, internal links, sitemap/RSS, resume.json)',
 );


### PR DESCRIPTION
## The hole

`isDraftAsset` in `scripts/verify-export.mjs` only fires when a draft post's **slug** is a whole path component under `POST_ASSET_ROOTS`. That makes it a rule about filenames — and a post's assets need not be named after it.

The draft `content/writing/why-i-mostly-switched-from-claude-code-to-codex-desktop-app.md` (`draft: true`) keeps three screenshots in `public/images/writing/codex-desktop-app-post/`. That directory name is not the slug and is not derived from it, so the gate reported `14 pages OK` while 116 KB of unpublished work shipped. The earlier, broader any-segment scan would not have caught it either — the string is not the slug in any form.

**This exposure predates the branch.** All three blobs are on `origin/main`:

```
$ git ls-tree -r --name-only origin/main -- public/images/writing/
public/images/writing/codex-desktop-app-post/codex-app-overview.webp
public/images/writing/codex-desktop-app-post/codex-automations.webp
public/images/writing/codex-desktop-app-post/codex-editor-diff.webp
...
```

The other draft gates work correctly — `out/writing/` has no draft route and `out/og/writing/` has no draft card. This was the missing piece.

## The fix

Gate on the post's own declaration rather than on names. A post declares its images, so `scripts/lib/markdown.mjs` reads them:

- the `image:` frontmatter field
- every image reference in the body — Markdown syntax including titles (`![alt](/p.png "Caption")`), angle-bracketed destinations, linked images (`[![alt](/p.png)](href)`, a form in use here), and inline `<img src>` since `markdown-to-jsx` renders raw HTML

Each resolves to a route; root-relative only, which is the form `validatePostFrontmatter` already requires of `image`. Off-site references are declined rather than resolved — a naive `new URL().pathname` on `https://cdn.example/images/photo.png` would have reported the local `out/images/photo.png` the draft never mentioned.

Then it **subtracts everything a published post also declares.** An illustration shared between a draft and a shipped post has to ship, and reporting it would be the same false-positive class the slug scan was already narrowed to avoid.

**Both checks stay, and they are complementary.** The slug rule catches what the build *derives* from a post — the share card is `og/writing/<slug>.png` by construction, and a leaked route's RSC `index.txt` sits inside `writing/<slug>/`. The Markdown cannot reference what the build invents. The reference rule catches what the author filed, wherever they filed it. Neither subsumes the other; the `POST_ASSET_ROOTS` comment now says which is which.

`isDraftFrontmatter` is imported from `scripts/og-inputs.mjs` as before — no third copy of the draft rule, and that file is otherwise untouched, so the card `generatorDigest` is unchanged (`npm run og:check` passes).

## The decision you may want to overrule

**The three images are reported, not deleted, and the gate exits 0.** They are yours; I did not touch them.

`DRAFT_REFERENCED_ASSETS_FAIL` in `verify-export.mjs` is `false`, and flipping that one line makes this class block the build. The reasoning:

- A file **named after** a draft is one the build produced from an unpublished post. The build is what gets fixed, no author is inconvenienced, and failing is right. Unchanged — still fatal.
- A file a draft **references** is the author's own. Committing screenshots alongside the draft that will use them is the normal way to write a post here, and the remedy is a decision about your working copy: move them out of `public/` until the post ships, or leave them knowing they are readable.

Failing would make that decision on your behalf by stopping every deploy from `main` the moment this lands, with nobody in the loop. And a red build does not un-expose the files — it only reports them. So it reports them, loudly, by name, with the full URL, and the count rides on the success line so a passing run never reads as clean:

```
verify-export: 3 warning(s), not blocking the build

  images/writing/codex-desktop-app-post/codex-app-overview.webp
    draft post "why-i-mostly-switched-from-claude-code-to-codex-desktop-app" references this
    file, so it is publicly fetchable at https://mldangelo.com/images/writing/codex-desktop-app-post/codex-app-overview.webp.
    Move it out of public/ until the post ships, or leave it knowing it is readable.
  ... (2 more)
verify-export: 14 pages OK, 3 warning(s) (draft routes and assets, robots, ...)
```

If you would rather it be fatal, flip the constant and move the three files out of `public/` in the same change — the post's Markdown paths need updating with them, which is why that is your call and not mine.

## Verification

- `npm run build` then `npm run verify-export`: all three real images named, exit 0, and the published post's `api-costs-july-2025.png` and `github-contributions-2025.png` correctly silent — the subtraction works on real data, not only fixtures.
- `npx vitest run`: 83 files, **1003 passed** (baseline 964, +39). Nothing regressed.
- `npx biome check .` clean, `npx tsc --noEmit` clean, `npm run format` no-op.
- `npm run og:check` and `npm run measure-export` still pass.
- **Mutation-checked**, per the AGENTS.md rule that a guard is only tested by an input that can reach it. Stubbing `declaredAssetRoutes` to return an empty set kills 13 tests including all three headline cases; removing the published-post subtraction kills exactly the two guards that pin it; removing the `isDraftAsset` dedupe kills the one-report test. All restored and green.

## Tests

`scripts/lib/` is imported directly as well as driven through the gate, for the reason `site.mjs` and `html.mjs` are: the awkward edges here — a title after the destination, an angle-bracketed path, a linked image, a scheme that is not http — never occur in this repository's own posts, so nothing would fail if they stopped working.

Required cases, all present:

- a draft image in an arbitrarily named directory is **reported**
- a published post's images **pass** silently
- a neighbouring file whose name only resembles a draft image (`shot-notes.png`) **passes** — the match is whole-path and must not grow into a prefix or directory rule, which is the false-positive class fixed recently
- an image a draft shares with a published post **passes**
- a draft image that also sits under a slug-named directory is reported **once**, as the failure

Plus: frontmatter-only declarations, off-site references, a draft image absent from the export, and the warning count on the success line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
