### PR TITLE
fix(theme): keep theme-color correct across client-side navigation

### DIFF
--- a/app/__tests__/theme-color.test.ts
+++ b/app/__tests__/theme-color.test.ts
@@ -1,16 +1,21 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it, vi } from 'vitest';
 
-import { THEME_COLOR_META_SELECTOR } from '@/lib/theme';
+import {
+  RESOLVED_THEME_COLOR_ATTRIBUTE,
+  THEME_COLOR_META_SELECTOR,
+} from '@/lib/theme';
 import { readColorToken } from '@/lib/tokens';
-import RootLayout, { viewport } from '../layout';
+import * as rootLayout from '../layout';
 
 // `next/font/local` only exists as a build-time transform, so importing the
-// root layout for its `viewport` export needs it stubbed. The stub returns the
-// shape `app/fonts.ts` destructures and nothing else. `vi.mock` is hoisted
-// above the import above, which is why this can be a static import rather than
-// a top-level `await import` — `target` here is es2015, which forbids one.
+// root layout needs it stubbed. The stub returns the shape `app/fonts.ts`
+// destructures and nothing else. `vi.mock` is hoisted above the import above,
+// which is why this can be a static import rather than a top-level
+// `await import` — `target` here is es2015, which forbids one.
 vi.mock('next/font/local', () => ({
   default: () => ({ variable: 'font-mock', className: 'font-mock', style: {} }),
 }));
@@ -18,29 +23,60 @@ vi.mock('next/font/local', () => ({
 const LIGHT = readColorToken('--color-bg-alt', 'light');
 const DARK = readColorToken('--color-bg-alt', 'dark');
 
+// No `s` flag: `target` here is es2015, which does not have one.
+const HEAD =
+  /<head>([\s\S]*?)<\/head>/.exec(
+    renderToStaticMarkup(createElement(rootLayout.default, { children: null })),
+  )?.[1] ?? '';
+
+const NOSCRIPT = /<noscript>([\s\S]*?)<\/noscript>/.exec(HEAD)?.[1] ?? '';
+
+/** Every stylesheet this project writes, as one string. */
+function projectStyles(): string {
+  const dir = join(process.cwd(), 'app', 'styles');
+  const files = readdirSync(dir, { recursive: true, encoding: 'utf8' })
+    .filter((name) => name.endsWith('.css'))
+    .map((name) => join(dir, name));
+
+  return [join(process.cwd(), 'app', 'tailwind.css'), ...files]
+    .map((path) => readFileSync(path, 'utf8'))
+    .join('\n');
+}
+
 /**
  * The export shipped with no `theme-color` at all, so mobile browsers painted
- * their chrome from their own default rather than from the page. A single
- * unscoped value only fixes that for one of the two themes, which is why this
- * pins the media-scoped pair rather than merely pinning that a value exists.
+ * their chrome from their own default rather than from the page. Then it
+ * shipped a media-scoped pair, which described a dark theme no visitor without
+ * JavaScript is ever served, and which React rebuilt out from under the
+ * bootstrap on every client-side navigation.
  *
- * The pair is scoped by the *device* preference, which is not what this site
- * themes off — `<html data-theme>` is, and a visitor can pin it against the
- * device. So the pair is what the page ships for a reader with no JavaScript,
- * and the bootstrap below repoints it at the rendered theme for everyone else.
+ * What ships now is one unscoped light value in `<noscript>` — the whole truth
+ * for a reader with no JavaScript — and one script-owned tag that carries the
+ * rendered theme for everyone else.
  */
 describe('theme-color', () => {
-  const themeColor = viewport.themeColor;
-
-  it('declares one media-scoped value per colour scheme', () => {
-    expect(Array.isArray(themeColor)).toBe(true);
-    expect(themeColor).toEqual([
-      { media: '(prefers-color-scheme: light)', color: LIGHT },
-      { media: '(prefers-color-scheme: dark)', color: DARK },
-    ]);
+  it('declares one unscoped value, for a reader with no JavaScript', () => {
+    expect(NOSCRIPT).toContain('name="theme-color"');
+    expect(NOSCRIPT).toContain(`content="${LIGHT}"`);
+    expect(NOSCRIPT).not.toContain('media=');
   });
 
-  it('declares two different colours, so the scoping does something', () => {
+  /**
+   * The premise of the line above, re-derived rather than asserted in prose:
+   * dark is reached only through `[data-theme]`, which the bootstrap sets, so
+   * a reader with no JavaScript gets the light page on every device and the
+   * light chrome is the only honest thing to declare for them.
+   *
+   * If a `prefers-color-scheme` block ever does land in the stylesheets — by
+   * hand, or through a Tailwind `dark:` utility, which defaults to that query —
+   * this goes red and points at the declaration that has to change with it.
+   */
+  it('is unscoped because no stylesheet reacts to the device preference', () => {
+    expect(projectStyles()).not.toContain('prefers-color-scheme');
+    expect(projectStyles()).toContain("[data-theme='dark']");
+  });
+
+  it('declares two different colours, so the theme switch does something', () => {
     expect(LIGHT).not.toBe(DARK);
   });
 
@@ -51,20 +87,30 @@ describe('theme-color', () => {
    * page's.
    */
   it('uses the page background, not the raised surface', () => {
-    const values = (
-      themeColor as ReadonlyArray<{ media?: string; color: string }>
-    ).map((entry) => entry.color);
+    expect(HEAD).not.toContain(readColorToken('--color-bg', 'light'));
+    expect(HEAD).not.toContain(readColorToken('--color-bg', 'dark'));
+  });
 
-    expect(values).not.toContain(readColorToken('--color-bg', 'light'));
-    expect(values).not.toContain(readColorToken('--color-bg', 'dark'));
+  /**
+   * The reason the fallback is in `<noscript>` and not in `viewport.themeColor`.
+   * React re-creates its hoisted `<meta>` elements on every client-side
+   * navigation and matches them back up by `content` and `name` but never by
+   * `media`, so a React-owned `theme-color` tag claims the script-owned one and
+   * then destroys it on the first `<Link>` press. Nothing React renders may be
+   * a `theme-color` tag.
+   */
+  it('renders no theme-color meta React could own', () => {
+    // `viewport.themeColor` is the only route from this file to a hoisted
+    // `theme-color` element, so the absence of the export *is* the property —
+    // and Next's own metadata does not appear in this render, which is why the
+    // markup cannot be asked instead.
+    expect('viewport' in rootLayout).toBe(false);
+    expect(HEAD.replace(/<noscript>[\s\S]*?<\/noscript>/g, '')).not.toContain(
+      '<meta name="theme-color"',
+    );
   });
 
   describe('bootstrap', () => {
-    // No `s` flag: `target` here is es2015, which does not have one.
-    const head = /<head>([\s\S]*?)<\/head>/.exec(
-      renderToStaticMarkup(createElement(RootLayout, { children: null })),
-    )?.[1];
-
     /**
      * A literal `<script>` with the body inline, which is the only kind that
      * runs before the page is painted. `<Script strategy="beforeInteractive">`
@@ -75,16 +121,25 @@ describe('theme-color', () => {
      * this assertion is the only place the distinction is visible.
      */
     it('ships the theme bootstrap as a parser-blocking inline script', () => {
-      expect(head).toMatch(/<script id="theme-init">\(function\(\)\{/);
-      expect(head).not.toContain('__next_s');
+      expect(HEAD).toMatch(/<script id="theme-init">\(function\(\)\{/);
+      expect(HEAD).not.toContain('__next_s');
     });
 
-    it('carries both chrome colours and the tags they belong to', () => {
-      // Read at build from the same token the pair above declares, so the
+    it('carries both chrome colours and creates the tag that holds one', () => {
+      // Read at build from the same token the fallback above declares, so the
       // scripted value and the no-JavaScript value cannot disagree.
-      expect(head).toContain(JSON.stringify(LIGHT));
-      expect(head).toContain(JSON.stringify(DARK));
-      expect(head).toContain(THEME_COLOR_META_SELECTOR);
+      expect(HEAD).toContain(JSON.stringify(LIGHT));
+      expect(HEAD).toContain(JSON.stringify(DARK));
+      // That the tag is unscoped and lands first is behaviour, not text, so it
+      // is pinned by running this script in `src/lib/__tests__/theme.test.ts`
+      // rather than by reading the minified body for a method name.
+      expect(HEAD).toContain(RESOLVED_THEME_COLOR_ATTRIBUTE);
+    });
+
+    it('queries no tag it did not create', () => {
+      // Repointing the page's own tags is the mechanism this replaced; a
+      // bootstrap that goes looking for them again has gone back to it.
+      expect(HEAD).not.toContain(THEME_COLOR_META_SELECTOR);
     });
   });
 });

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata, Viewport } from 'next';
+import type { Metadata } from 'next';
 
 import { SiteSchema } from '@/components/Schema';
 import GoogleAnalytics from '@/components/Template/GoogleAnalytics';
@@ -28,24 +28,35 @@ const CHROME_COLORS: ThemeColors = {
 };
 
 /**
- * `theme-color` paints the browser's own chrome — the Android address bar, the
- * Safari toolbar. One unscoped value is wrong in whichever theme it was not
- * picked for, so both are declared and scoped by `prefers-color-scheme`.
+ * The chrome colour for a visitor with no JavaScript, and for nobody else.
  *
- * That scoping is the *device* preference, and nothing in this project themes
- * off the device preference: the rendered theme is `<html data-theme>`, which
- * a visitor can pin to either value and which outlives the tab. So this pair
- * is the no-JavaScript answer — the best one available with no way to read the
- * stored choice — and the bootstrap below repoints both tags at the theme
- * actually being painted. Left alone, a visitor reading in dark mode on a
- * light device got a white address bar over a black page.
+ * `theme-color` paints the browser's own chrome — the Android address bar, the
+ * Safari toolbar — and cannot be styled, so it can only be scoped by
+ * `prefers-color-scheme`. That is the *device* preference, and no stylesheet
+ * here reacts to it: dark is reached only through `<html data-theme='dark'>`,
+ * which the bootstrap below sets. So a scoped pair painted dark chrome over a
+ * light page for a no-JavaScript visitor on a dark-preferring device — it
+ * described a dark theme they were never served.
+ * `app/__tests__/theme-color.test.ts` re-derives that premise from the
+ * stylesheets rather than trusting this comment.
+ *
+ * One unscoped light value is therefore the whole truth without JavaScript:
+ * that is the only page a reader can get, on any device. `app/manifest.json`
+ * says the same thing with its single `theme_color`.
+ *
+ * It lives in `<noscript>` because React must not own it. React re-creates its
+ * hoisted `<meta>` elements on every client-side navigation and matches them
+ * back up by `content`, `name`, `property`, `http-equiv` and `charset` — never
+ * `media` — so any React-rendered `theme-color` tag whose colour can equal a
+ * rendered theme will claim the script-owned tag instead and then destroy it on
+ * the next `<Link>` press. Measured before this changed: React owned the
+ * `media=light` node while it carried the dark colour. `<noscript>` puts the
+ * fallback exactly where it applies and nowhere React can reach.
+ *
+ * Interpolated straight into markup because `readColorToken` refuses anything
+ * that is not a literal hex, so the value cannot carry a quote or a tag.
  */
-export const viewport: Viewport = {
-  themeColor: [
-    { media: '(prefers-color-scheme: light)', color: CHROME_COLORS.light },
-    { media: '(prefers-color-scheme: dark)', color: CHROME_COLORS.dark },
-  ],
-};
+const NO_SCRIPT_THEME_COLOR = `<meta name="theme-color" content="${CHROME_COLORS.light}">`;
 
 /**
  * The icon set and the web app manifest are not declared here. They come from
@@ -118,19 +129,19 @@ export default function RootLayout({
       suppressHydrationWarning
     >
       <head>
+        <noscript dangerouslySetInnerHTML={{ __html: NO_SCRIPT_THEME_COLOR }} />
         {/* Theme bootstrap — prevents flash on load, stamps the *choice*
             alongside the resolved theme so the header's theme control can
             render its own state from the HTML instead of waiting for
-            hydration, and repoints the `theme-color` tags above at that same
-            theme. Built from the same constants the control uses.
+            hydration, and prepends the one `theme-color` tag that carries that
+            same theme. Built from the same constants the control uses.
 
             A plain inline script, not `<Script strategy="beforeInteractive">`:
             in the App Router that strategy serialises the body into
             `self.__next_s` and Next's `appBootstrap` runs it once the client
             chunks have loaded, which is long after first paint. Only a
             parser-blocking script runs before the page is painted, which is
-            the entire point of this one. It sits after the metadata Next
-            emits, so the tags it queries are already parsed. */}
+            the entire point of this one. */}
         <script
           id="theme-init"
           dangerouslySetInnerHTML={{ __html: themeInitScript(CHROME_COLORS) }}

--- a/src/components/Template/ThemeToggle.tsx
+++ b/src/components/Template/ThemeToggle.tsx
@@ -105,14 +105,18 @@ export default function ThemeToggle() {
       root.setAttribute(THEME_ATTRIBUTE, resolved);
     }
 
-    // The browser chrome is painted from `theme-color` meta tags, which the
-    // export scopes by `prefers-color-scheme` because that is all a static
-    // file can do. Nothing else here themes off the device, so once the
-    // attribute above is settled the tags have to be told what it says —
-    // including when the device flips underneath a `system` choice, which is
-    // the other reason this runs on every change rather than once at mount.
-    // Reads the token back out of the cascade, so it cannot name a colour the
-    // page is not painted with.
+    // The browser chrome is painted from a `theme-color` meta, which cannot be
+    // styled, so once the attribute above is settled the tag has to be told
+    // what it says — including when the device flips underneath a `system`
+    // choice, which is the other reason this runs on every change rather than
+    // once at mount. Reads the token back out of the cascade, so it cannot
+    // name a colour the page is not painted with.
+    //
+    // The pathname is deliberately *not* a dependency. It used to need to be,
+    // because this repointed the tags Next rendered and React rebuilt those on
+    // every client-side navigation, reverting the mutation. It now writes to a
+    // tag the bootstrap created, which React never owns and no navigation can
+    // touch — so the mutation survives without this effect having to chase it.
     syncThemeColor(document);
   }, [choice, systemScheme]);
 

--- a/src/components/__tests__/Template/ThemeToggle.test.tsx
+++ b/src/components/__tests__/Template/ThemeToggle.test.tsx
@@ -7,10 +7,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   DARK_SCHEME_QUERY,
+  RESOLVED_THEME_COLOR_SELECTOR,
   THEME_ATTRIBUTE,
   THEME_CHOICE_ATTRIBUTE,
+  THEME_COLOR_META_SELECTOR,
   THEME_COLOR_TOKEN,
   THEME_STORAGE_KEY,
+  themeInitScript,
 } from '@/lib/theme';
 import { readColorToken } from '@/lib/tokens';
 import ThemeToggle from '../../Template/ThemeToggle';
@@ -105,8 +108,12 @@ function renderUnhydrated(choice: string | null): Element {
 }
 
 /**
- * The `<head>` a real page has: the media-scoped `theme-color` pair from the
- * static export, and the token declarations `data-theme` switches between.
+ * The `<head>` a real page has: the token declarations `data-theme` switches
+ * between, and the `theme-color` tag the pre-paint bootstrap prepends.
+ *
+ * The bootstrap is run rather than imitated, because the tag it creates is the
+ * one the component then writes to — a stand-in could agree with the component
+ * while disagreeing with what actually ships.
  */
 function renderHead(): void {
   const style = document.createElement('style');
@@ -116,21 +123,45 @@ function renderHead(): void {
   document.head.append(style);
   unhydrated.push(style);
 
-  for (const scheme of ['light', 'dark'] as const) {
+  new Function(themeInitScript(CHROME_COLORS))();
+}
+
+/**
+ * The tags React hoists for a `viewport.themeColor` declaration, re-created
+ * from the build-time payload the way a client-side navigation re-creates them.
+ */
+function hoistThemeColorPair(): Element[] {
+  return (['light', 'dark'] as const).map((scheme) => {
     const meta = document.createElement('meta');
     meta.setAttribute('name', 'theme-color');
     meta.setAttribute('media', `(prefers-color-scheme: ${scheme})`);
     meta.setAttribute('content', CHROME_COLORS[scheme]);
     document.head.append(meta);
     unhydrated.push(meta);
-  }
+    return meta;
+  });
 }
 
 /** What the address bar is painted with, according to every tag on the page. */
 function chromeColors(): string[] {
-  return [...document.querySelectorAll('meta[name="theme-color"]')].map(
+  return [...document.querySelectorAll(THEME_COLOR_META_SELECTOR)].map(
     (meta) => meta.getAttribute('content') ?? '',
   );
+}
+
+/**
+ * What the browser would paint, modelled the way the spec reads it: the first
+ * tag in tree order that carries no `media` or whose `media` matches.
+ */
+function paintedChromeColor(prefersDark: boolean): string | null {
+  const query = `(prefers-color-scheme: ${prefersDark ? 'dark' : 'light'})`;
+
+  for (const meta of document.querySelectorAll(THEME_COLOR_META_SELECTOR)) {
+    const media = meta.getAttribute('media');
+    if (media === null || media === query) return meta.getAttribute('content');
+  }
+
+  return null;
 }
 
 function visibleStates(): (string | null)[] {
@@ -152,6 +183,11 @@ describe('ThemeToggle', () => {
   afterEach(() => {
     clearRoot();
     for (const node of unhydrated.splice(0)) node.remove();
+    // The bootstrap and the component both create their tag rather than taking
+    // one from a helper, so it is not in `unhydrated` to sweep.
+    for (const node of document.querySelectorAll(THEME_COLOR_META_SELECTOR)) {
+      node.remove();
+    }
   });
 
   describe('server-rendered markup', () => {
@@ -324,20 +360,17 @@ describe('ThemeToggle', () => {
     });
 
     it('repaints the browser chrome when the device flips', () => {
-      // `theme-color` is scoped by `prefers-color-scheme`, so the tags would
-      // follow this on their own — but they are no longer left to, and a
-      // pinned pair here would be stale for the rest of the visit.
-      renderHead();
+      // A media-scoped tag would follow this on its own, but the tag that
+      // carries the rendered theme is unscoped by design — so nothing but this
+      // moves it, and a stale reading would last the rest of the visit.
       const media = stubColorScheme(false);
+      renderHead();
       render(<ThemeToggle />);
-      expect(chromeColors()).toEqual([
-        CHROME_COLORS.light,
-        CHROME_COLORS.light,
-      ]);
+      expect(paintedChromeColor(false)).toBe(CHROME_COLORS.light);
 
       media.flipTo(true);
 
-      expect(chromeColors()).toEqual([CHROME_COLORS.dark, CHROME_COLORS.dark]);
+      expect(paintedChromeColor(true)).toBe(CHROME_COLORS.dark);
     });
 
     it('leaves the bootstrap theme alone when the device cannot be read', () => {
@@ -359,49 +392,43 @@ describe('ThemeToggle', () => {
 
   describe('browser chrome', () => {
     // The address bar and the toolbar are painted from `theme-color`, which
-    // only the device preference can scope. A visitor who picks a theme is
-    // saying the device preference does not apply to this page, so every
-    // change of `data-theme` has to be carried to the tags as well.
+    // cannot be styled and can only be scoped by the device preference. A
+    // visitor who picks a theme is saying the device preference does not apply
+    // to this page, so every change of `data-theme` has to be carried across.
     it('follows a chosen theme against the device', () => {
-      renderHead();
       stubColorScheme(true);
+      renderHead();
       render(<ThemeToggle />);
-      expect(chromeColors()).toEqual([CHROME_COLORS.dark, CHROME_COLORS.dark]);
+      expect(paintedChromeColor(true)).toBe(CHROME_COLORS.dark);
 
       // system -> light, on a device that prefers dark.
       fireEvent.click(toggle());
 
       expect(root().getAttribute(THEME_ATTRIBUTE)).toBe('light');
-      expect(chromeColors()).toEqual([
-        CHROME_COLORS.light,
-        CHROME_COLORS.light,
-      ]);
+      expect(paintedChromeColor(true)).toBe(CHROME_COLORS.light);
     });
 
     it('hands the chrome back to the device on the way round to system', () => {
-      renderHead();
       const media = stubColorScheme(false);
+      renderHead();
       render(<ThemeToggle />);
 
       // system -> light -> dark, pinned against a light device.
       fireEvent.click(toggle());
       fireEvent.click(toggle());
-      expect(chromeColors()).toEqual([CHROME_COLORS.dark, CHROME_COLORS.dark]);
+      expect(paintedChromeColor(false)).toBe(CHROME_COLORS.dark);
 
       fireEvent.click(toggle());
       expect(root().getAttribute(THEME_CHOICE_ATTRIBUTE)).toBe('system');
-      expect(chromeColors()).toEqual([
-        CHROME_COLORS.light,
-        CHROME_COLORS.light,
-      ]);
+      expect(paintedChromeColor(false)).toBe(CHROME_COLORS.light);
 
       media.flipTo(true);
-      expect(chromeColors()).toEqual([CHROME_COLORS.dark, CHROME_COLORS.dark]);
+      expect(paintedChromeColor(true)).toBe(CHROME_COLORS.dark);
     });
 
     it('never names a colour the page is not painted with', () => {
-      renderHead();
       stubColorScheme(true);
+      renderHead();
       render(<ThemeToggle />);
 
       for (let press = 0; press < 6; press += 1) {
@@ -410,23 +437,62 @@ describe('ThemeToggle', () => {
             ? CHROME_COLORS.dark
             : CHROME_COLORS.light;
 
-        expect(chromeColors()).toEqual([painted, painted]);
+        expect(paintedChromeColor(true)).toBe(painted);
         fireEvent.click(toggle());
       }
     });
 
-    it('leaves the scoped pair in place when no token resolves', () => {
+    it('paints from exactly one tag, however many the page ships', () => {
+      // Repointing the page's own tags left React unable to match its hoisted
+      // metas back up — it keys them by `content` — so it built another and the
+      // live document carried three where the export declared two.
+      stubColorScheme(true);
+      renderHead();
+      hoistThemeColorPair();
+      render(<ThemeToggle />);
+
+      expect(
+        document.querySelectorAll(RESOLVED_THEME_COLOR_SELECTOR),
+      ).toHaveLength(1);
+      expect(chromeColors()[0]).toBe(CHROME_COLORS.dark);
+    });
+
+    /**
+     * The bug this file did not catch: `syncThemeColor` runs on `[choice,
+     * systemScheme]`, and neither changes on a client-side navigation — but
+     * React re-creates every hoisted `<meta>` from the build-time payload on
+     * each one. Anything written into those tags is reverted by the first
+     * `<Link>` press, and it was: measured in Chrome against the export, a
+     * light device with dark pinned had the light chrome colour painted back
+     * over a dark page and kept it for the rest of the session.
+     */
+    it('survives a navigation that rebuilds the tags React owns', () => {
+      stubColorScheme(false);
+      renderHead();
+      const pair = hoistThemeColorPair();
+      render(<ThemeToggle />);
+
+      // system -> light -> dark: dark pinned on a light-preferring device,
+      // which is the direction that broke.
+      fireEvent.click(toggle());
+      fireEvent.click(toggle());
+      expect(root().getAttribute(THEME_ATTRIBUTE)).toBe('dark');
+      expect(paintedChromeColor(false)).toBe(CHROME_COLORS.dark);
+
+      // A client transition: the same tags, destroyed and rebuilt from the
+      // build-time values, with no state change to re-run the effect.
+      for (const meta of pair) meta.remove();
+      hoistThemeColorPair();
+
+      expect(paintedChromeColor(false)).toBe(CHROME_COLORS.dark);
+      expect(paintedChromeColor(true)).toBe(CHROME_COLORS.dark);
+    });
+
+    it('leaves the declared fallback in place when no token resolves', () => {
       // No stylesheet — a fork mid-rename, or styles that failed to load.
-      // Degrading to the device preference beats naming a colour from a
+      // Degrading to what the document declares beats naming a colour from a
       // palette that is not on the page.
-      for (const scheme of ['light', 'dark'] as const) {
-        const meta = document.createElement('meta');
-        meta.setAttribute('name', 'theme-color');
-        meta.setAttribute('media', `(prefers-color-scheme: ${scheme})`);
-        meta.setAttribute('content', CHROME_COLORS[scheme]);
-        document.head.append(meta);
-        unhydrated.push(meta);
-      }
+      hoistThemeColorPair();
 
       render(<ThemeToggle />);
       fireEvent.click(toggle());

--- a/src/lib/__tests__/theme.test.ts
+++ b/src/lib/__tests__/theme.test.ts
@@ -4,6 +4,7 @@ import {
   applyThemeColor,
   DARK_SCHEME_QUERY,
   nextThemeChoice,
+  RESOLVED_THEME_COLOR_SELECTOR,
   readStoredThemeChoice,
   renderedThemeColor,
   resolveTheme,
@@ -12,6 +13,7 @@ import {
   THEME_ATTRIBUTE,
   THEME_CHOICE_ATTRIBUTE,
   THEME_CHOICES,
+  THEME_COLOR_META_SELECTOR,
   THEME_COLOR_TOKEN,
   THEME_STORAGE_KEY,
   type ThemeChoice,
@@ -37,18 +39,51 @@ function runThemeInitScript(): void {
 const injected: Element[] = [];
 
 /**
- * The media-scoped pair the static export ships, as a browser parses it —
- * both tags present, whatever the device happens to prefer.
+ * A media-scoped pair, hoisted into `<head>` the way React hoists the ones a
+ * fork might declare through `viewport.themeColor`.
+ *
+ * The export no longer ships these — its fallback lives in `<noscript>` — but
+ * the script-owned tag has to win against them anyway, because that is what
+ * makes it durable rather than merely first to run.
  */
-function addThemeColorMetas(): void {
-  for (const scheme of ['light', 'dark'] as const) {
+function addThemeColorMetas(): Element[] {
+  const added = ['light', 'dark'].map((scheme) => {
     const meta = document.createElement('meta');
     meta.setAttribute('name', 'theme-color');
     meta.setAttribute('media', `(prefers-color-scheme: ${scheme})`);
-    meta.setAttribute('content', CHROME_COLORS[scheme]);
+    meta.setAttribute('content', CHROME_COLORS[scheme as 'light' | 'dark']);
     document.head.append(meta);
     injected.push(meta);
+    return meta;
+  });
+
+  return added;
+}
+
+/** The content of the one tag the bootstrap and the toggle both write to. */
+function resolvedChromeColor(): string | null {
+  return (
+    document
+      .querySelector(RESOLVED_THEME_COLOR_SELECTOR)
+      ?.getAttribute('content') ?? null
+  );
+}
+
+/**
+ * What the browser would paint, modelled the way the spec says: the first tag
+ * in tree order whose `media` matches, or which carries no `media` at all.
+ */
+function paintedChromeColor(prefersDark: boolean): string | null {
+  for (const meta of document.querySelectorAll(THEME_COLOR_META_SELECTOR)) {
+    const media = meta.getAttribute('media');
+    const matches =
+      media === null ||
+      media === `(prefers-color-scheme: ${prefersDark ? 'dark' : 'light'})`;
+
+    if (matches) return meta.getAttribute('content');
   }
+
+  return null;
 }
 
 /**
@@ -128,6 +163,11 @@ describe('theme', () => {
   afterEach(() => {
     clearRoot();
     for (const node of injected.splice(0)) node.remove();
+    // The script-owned tag is created by the code under test rather than by a
+    // helper, so it is not in `injected` and has to be swept separately.
+    for (const node of document.querySelectorAll(THEME_COLOR_META_SELECTOR)) {
+      node.remove();
+    }
   });
 
   describe('nextThemeChoice', () => {
@@ -283,9 +323,9 @@ describe('theme', () => {
     });
 
     it('paints the chrome from the stored choice, not from the device', () => {
-      // The bug: the meta tags are scoped by `prefers-color-scheme`, so a
-      // visitor reading in light mode on a dark device got a black address
-      // bar over a white page — and the reverse.
+      // The bug: a `theme-color` tag can only be scoped by
+      // `prefers-color-scheme`, so a visitor reading in light mode on a dark
+      // device got a black address bar over a white page — and the reverse.
       addThemeColorMetas();
       setPrefersDark(true);
       window.localStorage.setItem(THEME_STORAGE_KEY, 'light');
@@ -293,49 +333,109 @@ describe('theme', () => {
       runThemeInitScript();
 
       expect(themeAttribute()).toBe('light');
-      expect(chromeColors()).toEqual([
-        CHROME_COLORS.light,
-        CHROME_COLORS.light,
-      ]);
+      expect(resolvedChromeColor()).toBe(CHROME_COLORS.light);
+      expect(paintedChromeColor(true)).toBe(CHROME_COLORS.light);
     });
 
     it('paints the chrome from the device while the choice is system', () => {
-      // Following the device is what `system` means, so the scoping is right
-      // here and the resolved value has to agree with it rather than fight it.
+      // Following the device is what `system` means, so the resolved value has
+      // to agree with it rather than fight it.
       addThemeColorMetas();
       setPrefersDark(true);
 
       runThemeInitScript();
 
       expect(themeAttribute()).toBe('dark');
-      expect(chromeColors()).toEqual([CHROME_COLORS.dark, CHROME_COLORS.dark]);
+      expect(resolvedChromeColor()).toBe(CHROME_COLORS.dark);
+      expect(paintedChromeColor(true)).toBe(CHROME_COLORS.dark);
+    });
+
+    it('leaves the tags it did not create exactly as it found them', () => {
+      // Repointing them is what React undoes on the first client-side
+      // navigation, because it matches its own hoisted metas back up by
+      // `content` and rebuilds any it cannot find.
+      const pair = addThemeColorMetas();
+      setPrefersDark(true);
+
+      runThemeInitScript();
+
+      expect(pair.map((meta) => meta.getAttribute('content'))).toEqual([
+        CHROME_COLORS.light,
+        CHROME_COLORS.dark,
+      ]);
+    });
+
+    it('adds one unscoped tag, ahead of everything else', () => {
+      // Unscoped so it always matches, first so it always wins: those two
+      // together are why no navigation and no tag order can unseat it.
+      addThemeColorMetas();
+
+      runThemeInitScript();
+
+      const metas = [...document.querySelectorAll(THEME_COLOR_META_SELECTOR)];
+      expect(metas).toHaveLength(3);
+      expect(metas[0].hasAttribute('media')).toBe(false);
+      expect(metas[0].matches(RESOLVED_THEME_COLOR_SELECTOR)).toBe(true);
+    });
+
+    it('creates the same tag applyThemeColor writes to', () => {
+      // The script cannot import the selector it is built from, so this is the
+      // only thing keeping the created tag and the written tag from drifting
+      // into two tags — which is what a mismatch would silently become.
+      runThemeInitScript();
+      applyThemeColor(document, CHROME_COLORS.dark);
+
+      expect(chromeColors()).toEqual([CHROME_COLORS.dark]);
     });
 
     it('runs on a page with no theme-color tags at all', () => {
-      // A fork that drops the viewport export still gets its theme.
+      // A fork that drops the `<noscript>` fallback still gets its theme.
       expect(runThemeInitScript).not.toThrow();
       expect(themeAttribute()).toBe('light');
+      expect(resolvedChromeColor()).toBe(CHROME_COLORS.light);
     });
   });
 
   describe('applyThemeColor', () => {
-    it('points every tag at one colour, whatever each is scoped to', () => {
-      // Which tag the browser picks stops mattering once they agree, so this
-      // needs no opinion about `theme-color` precedence between them.
+    it('creates one unscoped tag ahead of any the page already has', () => {
       addThemeColorMetas();
 
       applyThemeColor(document, CHROME_COLORS.dark);
 
-      expect(chromeColors()).toEqual([CHROME_COLORS.dark, CHROME_COLORS.dark]);
+      expect(paintedChromeColor(false)).toBe(CHROME_COLORS.dark);
+      expect(paintedChromeColor(true)).toBe(CHROME_COLORS.dark);
     });
 
-    it('leaves the media-scoped pair alone rather than emptying it', () => {
+    it('reuses its own tag rather than adding one per call', () => {
+      applyThemeColor(document, CHROME_COLORS.dark);
+      applyThemeColor(document, CHROME_COLORS.light);
+      applyThemeColor(document, CHROME_COLORS.dark);
+
+      expect(chromeColors()).toEqual([CHROME_COLORS.dark]);
+    });
+
+    it('leaves the page it was given untouched', () => {
+      // Mutating the tags the document shipped is the mechanism this replaced:
+      // React re-creates its own hoisted metas on navigation, so a mutation
+      // there lasts until the visitor follows one link.
+      const pair = addThemeColorMetas();
+
+      applyThemeColor(document, CHROME_COLORS.dark);
+
+      expect(pair.map((meta) => meta.getAttribute('content'))).toEqual([
+        CHROME_COLORS.light,
+        CHROME_COLORS.dark,
+      ]);
+    });
+
+    it('adds no tag at all when no colour resolves', () => {
       // An empty `content` is skipped by the browser, which falls back to its
-      // own default chrome — strictly worse than the scoped pair already here.
+      // own default chrome — strictly worse than the fallback already here.
       addThemeColorMetas();
 
       applyThemeColor(document, '');
 
+      expect(document.querySelector(RESOLVED_THEME_COLOR_SELECTOR)).toBeNull();
       expect(chromeColors()).toEqual([CHROME_COLORS.light, CHROME_COLORS.dark]);
     });
   });
@@ -359,26 +459,40 @@ describe('theme', () => {
   describe('syncThemeColor', () => {
     it('follows data-theme, which is the only thing the styles follow', () => {
       addTokenStylesheet();
-      addThemeColorMetas();
 
       document.documentElement.setAttribute(THEME_ATTRIBUTE, 'dark');
       syncThemeColor(document);
-      expect(chromeColors()).toEqual([CHROME_COLORS.dark, CHROME_COLORS.dark]);
+      expect(resolvedChromeColor()).toBe(CHROME_COLORS.dark);
 
       document.documentElement.setAttribute(THEME_ATTRIBUTE, 'light');
       syncThemeColor(document);
-      expect(chromeColors()).toEqual([
-        CHROME_COLORS.light,
-        CHROME_COLORS.light,
-      ]);
+      expect(resolvedChromeColor()).toBe(CHROME_COLORS.light);
     });
 
-    it('degrades to the media-scoped pair when no token resolves', () => {
+    it('degrades to whatever the page already declares when no token resolves', () => {
       addThemeColorMetas();
 
       syncThemeColor(document);
 
       expect(chromeColors()).toEqual([CHROME_COLORS.light, CHROME_COLORS.dark]);
+    });
+
+    it('holds its reading while React rebuilds the tags it owns', () => {
+      // An App Router client-side navigation destroys and re-creates every
+      // hoisted `<meta>`, from the build-time payload. Anything written into
+      // one of those is gone; the tag written here is not React's to rebuild.
+      addTokenStylesheet();
+      const pair = addThemeColorMetas();
+
+      document.documentElement.setAttribute(THEME_ATTRIBUTE, 'dark');
+      syncThemeColor(document);
+      expect(paintedChromeColor(false)).toBe(CHROME_COLORS.dark);
+
+      for (const meta of pair) meta.remove();
+      addThemeColorMetas();
+
+      expect(paintedChromeColor(false)).toBe(CHROME_COLORS.dark);
+      expect(paintedChromeColor(true)).toBe(CHROME_COLORS.dark);
     });
   });
 });

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -11,9 +11,11 @@
  *   render its own state — which is what forced it to wait for hydration and
  *   leave a 44x44 hole in the header.
  *
- * The `theme-color` meta tags follow `data-theme` too, for the same reason
- * every stylesheet does: an explicit choice is allowed to disagree with the
- * device, and the browser chrome has to be the colour immediately under it.
+ * The browser chrome follows `data-theme` too, for the same reason every
+ * stylesheet does: an explicit choice is allowed to disagree with the device,
+ * and the chrome has to be the colour immediately under it. It cannot be
+ * styled, so it gets a `theme-color` meta of its own —
+ * {@link RESOLVED_THEME_COLOR_ATTRIBUTE}.
  *
  * The functions that touch `window` are browser-only by design; the module has
  * no `'use client'` marker so `app/layout.tsx` can build the bootstrap script
@@ -37,18 +39,32 @@ export const DARK_SCHEME_QUERY = '(prefers-color-scheme: dark)';
  */
 export const THEME_COLOR_TOKEN = '--color-bg-alt';
 
+/** Every `theme-color` meta, whoever created it. */
+export const THEME_COLOR_META_SELECTOR = 'meta[name="theme-color"]';
+
 /**
- * Every `theme-color` meta, not the one that happens to match the device.
+ * The mark on the one `theme-color` meta that carries the *rendered* theme.
  *
  * `theme-color` has no `data-theme` selector, so the only lever from script is
- * the `content` of the tags themselves. The static export ships the
- * media-scoped pair from `app/layout.tsx` — that is the answer for a visitor
- * with no JavaScript, and the only correct one available without it. Once
- * script runs, the device preference stops being the question, so every tag is
- * pointed at the rendered theme and it no longer matters which one the browser
- * picks.
+ * a tag's `content`. Repointing the tags the page already shipped is the
+ * obvious move and it does not hold: React owns those and re-creates them on
+ * every client-side navigation, from the build-time payload. Worse, it matches
+ * them back up by `content` and `name` but never by `media`, so a repointed tag
+ * is claimed by whichever hoisted meta now shares its colour and a third tag is
+ * built for the one left unmatched. Measured on the export: two tags declared,
+ * three in the live document, and the first `<Link>` press put the light chrome
+ * colour back over a dark page for the rest of the session.
+ *
+ * So the rendered theme gets a tag of its own, created by
+ * {@link themeInitScript} before first paint and never rendered by React. It
+ * carries no `media`, so it always matches, and it is prepended to `<head>`, so
+ * it is first in tree order — the two things that make the browser paint from
+ * it. React cannot revert what it does not own.
  */
-export const THEME_COLOR_META_SELECTOR = 'meta[name="theme-color"]';
+export const RESOLVED_THEME_COLOR_ATTRIBUTE = 'data-theme-color';
+
+/** The script-owned tag from {@link RESOLVED_THEME_COLOR_ATTRIBUTE}, alone. */
+export const RESOLVED_THEME_COLOR_SELECTOR = `${THEME_COLOR_META_SELECTOR}[${RESOLVED_THEME_COLOR_ATTRIBUTE}]`;
 
 /** The chrome colour for each theme, lifted out of the stylesheets at build. */
 export type ThemeColors = Readonly<Record<ResolvedTheme, string>>;
@@ -131,18 +147,40 @@ export function storeThemeChoice(choice: ThemeChoice): void {
 }
 
 /**
- * Point every `theme-color` meta at one colour.
+ * The script-owned `theme-color` meta, created on first use.
  *
- * An empty colour is a no-op rather than an empty `content`: a tag with no
- * usable value is skipped by the browser, which would drop back to its own
- * default chrome instead of to the media-scoped value that is already there.
+ * Prepended rather than appended: the browser paints from the first tag in
+ * tree order whose `media` matches, and this one carries no `media`, so being
+ * first is what makes it the answer whatever else the page ships. Landing
+ * above `<meta charset>` costs nothing — the document was decoded while it was
+ * parsed, and this runs after that.
+ */
+function resolvedThemeColorMeta(doc: Document): HTMLMetaElement {
+  const existing = doc.head.querySelector<HTMLMetaElement>(
+    RESOLVED_THEME_COLOR_SELECTOR,
+  );
+  if (existing) return existing;
+
+  const meta = doc.createElement('meta');
+  meta.setAttribute('name', 'theme-color');
+  meta.setAttribute(RESOLVED_THEME_COLOR_ATTRIBUTE, '');
+  doc.head.prepend(meta);
+
+  return meta;
+}
+
+/**
+ * Point the browser chrome at one colour.
+ *
+ * An empty colour is a no-op rather than an empty `content`, and rather than a
+ * tag at all: a tag with no usable value is skipped by the browser, so an
+ * empty one would drop the page back to default chrome instead of to the
+ * `<noscript>` value `app/layout.tsx` ships.
  */
 export function applyThemeColor(doc: Document, color: string): void {
   if (!color) return;
 
-  for (const meta of doc.querySelectorAll(THEME_COLOR_META_SELECTOR)) {
-    meta.setAttribute('content', color);
-  }
+  resolvedThemeColorMeta(doc).setAttribute('content', color);
 }
 
 /**
@@ -151,8 +189,8 @@ export function applyThemeColor(doc: Document, color: string): void {
  * Deliberately the computed token rather than a hex handed to the client: the
  * cascade has already answered this question, so this cannot disagree with
  * what is on screen the way a second copy of the palette could. Returns `''`
- * when the stylesheet has not resolved — {@link applyThemeColor} then leaves
- * the existing tags alone.
+ * when the stylesheet has not resolved — {@link applyThemeColor} then adds no
+ * tag at all.
  */
 export function renderedThemeColor(doc: Document): string {
   const view = doc.defaultView;
@@ -182,10 +220,13 @@ export function syncThemeColor(doc: Document): void {
  * that throws used to abort the whole function and ship a page with no
  * `data-theme` at all.
  *
- * It also settles the chrome colour, in the same pass and from the same
+ * It also adds the chrome colour's tag, in the same pass and from the same
  * resolved theme, because a returning visitor whose stored choice contradicts
- * their device would otherwise have the address bar painted from the media
- * query for the whole of the first paint. The colours are passed in rather
+ * their device would otherwise read the whole first paint with the address bar
+ * painted from a device preference nothing else here follows. This is the only
+ * place that tag is created — {@link applyThemeColor} finds it afterwards and
+ * would otherwise create a second one, which `theme.test.ts` checks by running
+ * this script and then calling that function. The colours are passed in rather
  * than read here: they come from `readColorToken`, which reads the filesystem
  * and must not reach the client bundle. They are embedded through
  * `JSON.stringify` so a value can never break out of the string literal.
@@ -194,5 +235,5 @@ export function themeInitScript(colors: ThemeColors): string {
   const light = JSON.stringify(colors.light);
   const dark = JSON.stringify(colors.dark);
 
-  return `(function(){var c='system';try{var s=window.localStorage.getItem('${THEME_STORAGE_KEY}');if(s==='light'||s==='dark'){c=s}}catch(e){}var r=document.documentElement;r.setAttribute('${THEME_CHOICE_ATTRIBUTE}',c);var t=c;if(c==='system'){t='light';try{if(window.matchMedia('${DARK_SCHEME_QUERY}').matches){t='dark'}}catch(e){}}r.setAttribute('${THEME_ATTRIBUTE}',t);var k=t==='dark'?${dark}:${light},m=document.querySelectorAll('${THEME_COLOR_META_SELECTOR}');for(var i=0;i<m.length;i++){m[i].setAttribute('content',k)}})();`;
+  return `(function(){var c='system';try{var s=window.localStorage.getItem('${THEME_STORAGE_KEY}');if(s==='light'||s==='dark'){c=s}}catch(e){}var r=document.documentElement;r.setAttribute('${THEME_CHOICE_ATTRIBUTE}',c);var t=c;if(c==='system'){t='light';try{if(window.matchMedia('${DARK_SCHEME_QUERY}').matches){t='dark'}}catch(e){}}r.setAttribute('${THEME_ATTRIBUTE}',t);var m=document.createElement('meta');m.setAttribute('name','theme-color');m.setAttribute('${RESOLVED_THEME_COLOR_ATTRIBUTE}','');m.setAttribute('content',t==='dark'?${dark}:${light});document.head.prepend(m)})();`;
 }


### PR DESCRIPTION
Three defects in one mechanism: the browser chrome colour. All three were reproduced in headless Chrome against the built export before and after the change; the numbers below are measurements, not estimates.

## 1. `theme-color` reverted after the first client-side navigation

`syncThemeColor` repointed the `theme-color` metas the export shipped, and React owns those. It re-creates them on every App Router client transition from the build-time payload, and — confirmed by reading `react-dom` 19.2.8 — it matches hoisted `<meta>` elements back up by `content`, `name`, `property`, `http-equiv` and `charset`, but **never** `media`. So a repointed tag was claimed by whichever hoisted meta happened to share its colour, and a third tag was built for the one left unmatched.

Measured on `out/`, device light with dark pinned:

| | route | `theme-color` metas | `--color-bg-alt` | painted | agree |
|---|---|---|---|---|---|
| before | `/` | 3 | `#0d1015` | `#0d1015` | yes |
| after `<Link>` | `/about/` | 3 | `#0d1015` | `#f2f1ec` | **no** |

React owned the `media=light` node while it carried the dark colour. The reverse direction (device dark, light pinned) stayed correct on tree-order luck alone, as the audit predicted.

**Fix:** the rendered theme gets a tag of its own. The pre-paint bootstrap prepends one unscoped `<meta name="theme-color" data-theme-color>` and `applyThemeColor` writes only to that. Unscoped so it always matches, first in tree order so it always wins, script-created so React never owns it. No navigation can revert what React does not render — so `usePathname` is not needed as an effect dependency, and the tree-order fragility is gone rather than worked around.

After, all four device/stored-choice combinations, three navigations deep, with the toggle pressed after a navigation:

```
nav      /           choice=dark    count=1 bgAlt=#0d1015 painted=#0d1015 AGREE=true
nav      /about/     choice=dark    count=1 bgAlt=#0d1015 painted=#0d1015 AGREE=true
nav      /projects/  choice=dark    count=1 bgAlt=#0d1015 painted=#0d1015 AGREE=true
nav      /writing/   choice=dark    count=1 bgAlt=#0d1015 painted=#0d1015 AGREE=true
press 1  /writing/   choice=system  count=1 bgAlt=#f2f1ec painted=#f2f1ec AGREE=true
press 2  /writing/   choice=light   count=1 bgAlt=#f2f1ec painted=#f2f1ec AGREE=true
press 3  /writing/   choice=dark    count=1 bgAlt=#0d1015 painted=#0d1015 AGREE=true
nav      /resume/    choice=dark    count=1 bgAlt=#0d1015 painted=#0d1015 AGREE=true
```

## 2. A third `theme-color` meta in the live DOM

Counted, as requested. The export declared **2**; the hydrated document carried **3**, in every direction tested — React could not find the tags it rendered once their `content` had been mutated, so it built a replacement. Resolved by construction: React now renders no `theme-color` element at all, and the live document carries exactly **1**.

## 3. No-JS visitors on a dark device got dark chrome over a light page

The premise checks out at the strongest level: the **built** CSS contains zero occurrences of `prefers-color-scheme` (`grep -c` on `out/_next/static/css/*.css` → 0), and every dark token lives under `[data-theme='dark']`, which only the bootstrap sets. With scripts disabled, `data-theme` was absent (light page) while the `media=dark` meta matched and painted dark chrome.

**Chosen: drop the dark half.** A reader without JavaScript gets the light page on *every* device, so one unscoped light value is the whole truth for them — and `app/manifest.json` already declares exactly that single `theme_color`. The alternative, adding a `prefers-color-scheme` fallback to the stylesheets, would duplicate the whole dark palette, introduce a second theming axis against the documented "every stylesheet keys off `data-theme` and nothing else", and be dead code for every visitor with JavaScript.

The fallback also moves into `<noscript>`, which is what keeps React from owning a `theme-color` tag — the property defect 1's fix depends on. Verified with scripts disabled: one unscoped light tag, on both a dark- and a light-preferring device.

## Testing — the gap that let this ship

`ThemeToggle.test.tsx` built a synthetic `<head>` and never simulated a navigation. It now runs the *real* bootstrap for its head (so the tag under test is the one that ships), models which tag a browser would paint from per the spec, and destroys and rebuilds the hoisted metas mid-test with no state change to re-run the effect.

Verified by mutation, both directions:

- reverting `applyThemeColor` to the loop over every tag → **18 tests fail**, including `survives a navigation that rebuilds the tags React owns`
- `prepend` → `append`, keeping everything else → **4 tests fail**, including the same one

`theme-color.test.ts` also re-derives defect 3's premise from the stylesheets, so if a `prefers-color-scheme` block ever lands the test points at the declaration that has to change with it.

## Gates

`npm run format`; `npx biome check .` clean; `npx tsc --noEmit` clean; `npx vitest run` 976 passed / 83 files, up from a 965 baseline with nothing regressed; `npm run build`, `npm run verify-export` (14 pages OK) and `npm run measure-export` (7 budgets within limits) all green.

Built on `fix/theme-toggle-doc-selfcontradiction`, which was deleted from the remote mid-run; its tip (`e47f5bd`) is already an ancestor of `integration/site-improvements`, so this targets that instead and the diff is only the six files above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
